### PR TITLE
Change mentions of 'the dockstore' to 'Dockstore'

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/JCommanderUtility.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/JCommanderUtility.java
@@ -48,12 +48,12 @@ public final class JCommanderUtility {
         printJCommanderHelpUsage(programName, commandName, jc);
         printJCommanderHelpDescription(description);
         out("Required parameters:\n"
-                + "  --entry <entry>                     Complete workflow path in the Dockstore (ex. NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq:master)\n"
+                + "  --entry <entry>                     Complete workflow path in Dockstore (ex. NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq:master)\n"
                 + "   OR\n"
                 + "  --local-entry <local-entry>         Allows you to specify a full path to a local descriptor instead of an entry path\n");
         out("Optional parameters:\n"
-                + "  --json <json file>                  Parameters to the entry in the dockstore, one map for one run, an array of maps for multiple runs\n"
-                + "  --yaml <yaml file>                  Parameters to the entry in the dockstore, one map for one run, an array of maps for multiple runs\n"
+                + "  --json <json file>                  Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs\n"
+                + "  --yaml <yaml file>                  Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs\n"
                 + "  --tsv <tsv file>                    One row corresponds to parameters for one run in the dockstore (Only for CWL)\n"
                 + "  --wdl-output-target                 Allows you to specify a remote path to provision output files to ex: s3://oicr.temp/testing-launcher/\n"
                 + "  --uuid                              Allows you to specify a uuid for 3rd party notifications\n");

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -175,7 +175,7 @@ public abstract class AbstractEntryClient<T> {
         out("");
         out("  search           :  allows a user to search for all published " + getEntryType() + "s that match the criteria");
         out("");
-        out("  publish          :  publish/unpublish a " + getEntryType() + " in the dockstore");
+        out("  publish          :  publish/unpublish a " + getEntryType() + " in Dockstore");
         out("");
         out("  info             :  print detailed information about a particular published " + getEntryType());
         out("");
@@ -188,7 +188,7 @@ public abstract class AbstractEntryClient<T> {
         out("");
         out("  label            :  updates labels for an individual " + getEntryType() + "");
         out("");
-        out("  star             :  star/unstar a " + getEntryType() + " in the dockstore");
+        out("  star             :  star/unstar a " + getEntryType() + " in Dockstore");
         out("");
         out("  test_parameter   :  updates test parameter files for a version of a " + getEntryType() + "");
         out("");
@@ -1361,7 +1361,7 @@ public abstract class AbstractEntryClient<T> {
         out("  No arguments will list the current and potential " + getEntryType() + "s to share.");
         out("Required Parameters:");
         out("  --entry <" + getEntryType() + ">             Complete " + getEntryType()
-                + " path in the Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
+                + " path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
         printHelpFooter();
     }
 
@@ -1384,7 +1384,7 @@ public abstract class AbstractEntryClient<T> {
         out("  Add or remove labels from a given Dockstore " + getEntryType());
         out("");
         out("Required Parameters:");
-        out("  --entry <entry>                             Complete " + getEntryType() + " path in the Dockstore");
+        out("  --entry <entry>                             Complete " + getEntryType() + " path in Dockstore");
         out("");
         out("Optional Parameters:");
         out("  --add <label> (--add <label>)               Add given label(s)");
@@ -1402,7 +1402,7 @@ public abstract class AbstractEntryClient<T> {
         out("");
         out("Required Parameters:");
         out("  --entry <entry>                                                          Complete " + getEntryType()
-                + " path in the Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
+                + " path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
         out("  --version <version>                                                      " + getEntryType() + " version name");
         if (getEntryType().equalsIgnoreCase("tool")) {
             out("  --descriptor-type <descriptor-type>                                      CWL/WDL");
@@ -1424,7 +1424,7 @@ public abstract class AbstractEntryClient<T> {
         out("");
         out("Required Parameters:");
         out("  --entry <entry>     The complete " + getEntryType()
-                + " path in the Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
+                + " path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
         printHelpFooter();
     }
 
@@ -1438,7 +1438,7 @@ public abstract class AbstractEntryClient<T> {
         out("");
         out("Required parameters:");
         out("  --entry <entry>              Complete " + getEntryType()
-                + " path in the Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow:develop)");
+                + " path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow:develop)");
         printHelpFooter();
     }
 
@@ -1452,7 +1452,7 @@ public abstract class AbstractEntryClient<T> {
         out("  Refresh an individual " + getEntryType() + " or all your " + getEntryType() + ".");
         out("");
         out("Optional Parameters:");
-        out("  --entry <entry>         Complete tool path in the Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
+        out("  --entry <entry>         Complete tool path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
         printHelpFooter();
     }
 
@@ -1532,7 +1532,7 @@ public abstract class AbstractEntryClient<T> {
         out("");
         out("Required parameters:");
         out("  --entry <entry>                Complete " + getEntryType().toLowerCase()
-                + " path in the Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow:develop)");
+                + " path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow:develop)");
         printHelpFooter();
     }
 
@@ -1546,7 +1546,7 @@ public abstract class AbstractEntryClient<T> {
         out("");
         out("Required parameters:");
         out("  --entry <entry>                Complete " + getEntryType().toLowerCase()
-                + " path in the Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow:develop)");
+                + " path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow:develop)");
         out("  --descriptor <descriptor>      Type of descriptor language used. Defaults to cwl");
         printHelpFooter();
     }
@@ -1560,7 +1560,7 @@ public abstract class AbstractEntryClient<T> {
         out("  Download an entry to the working directory.");
         out("");
         out("Required parameters:");
-        out("  --entry <entry>          Complete entry path in the Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow:develop)");
+        out("  --entry <entry>          Complete entry path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow:develop)");
         out("");
         out("Optional parameters:");
         out("  --zip               Keep the zip file rather than uncompress the files within");
@@ -1573,15 +1573,15 @@ public abstract class AbstractEntryClient<T> {
         out("  Launch an entry locally.");
         out("");
         out("Required parameters:");
-        out("  --entry <entry>                     Complete entry path in the Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow:develop)");
+        out("  --entry <entry>                     Complete entry path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow:develop)");
         if (!(this instanceof CheckerClient)) {
             out("   OR");
             out("  --local-entry <local-entry>         Allows you to specify a full path to a local descriptor instead of an entry path");
         }
         out("");
         out("Optional parameters:");
-        out("  --json <json file>                  Parameters to the entry in the dockstore, one map for one run, an array of maps for multiple runs");
-        out("  --yaml <yaml file>                  Parameters to the entry in the dockstore, one map for one run, an array of maps for multiple runs");
+        out("  --json <json file>                  Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs");
+        out("  --yaml <yaml file>                  Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs");
         out("  --descriptor <descriptor type>      Descriptor type used to launch workflow. Defaults to " + CWL.getLowerShortName());
         if (!(this instanceof CheckerClient)) {
             out("  --local-entry                       Allows you to specify a full path to a local descriptor for --entry instead of an entry path");
@@ -1609,7 +1609,7 @@ public abstract class AbstractEntryClient<T> {
         out("  Verify/unverify a version.");
         out("");
         out("Required parameters:");
-        out("  --entry <entry>                              Complete entry path in the Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
+        out("  --entry <entry>                              Complete entry path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
         out("  --version <version>                          Version name");
         out("");
         out("Optional Parameters:");

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -132,7 +132,7 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
         out("       dockstore " + getEntryType().toLowerCase() + " manual_publish [parameters]");
         out("");
         out("Description:");
-        out("  Manually register an workflow in the dockstore. If this is successful and the workflow is valid, then publish.");
+        out("  Manually register a workflow in dockstore. If this is successful and the workflow is valid, then publish.");
         out("");
         out("Required parameters:");
         out("  --repository <repository>                            Name for the git repository");
@@ -157,7 +157,7 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
         out("  Update certain fields for a given workflow.");
         out("");
         out("Required Parameters:");
-        out("  --entry <entry>                                              Complete workflow path in the Dockstore (ex. github.com/collaboratory/seqware-bwa-workflow)");
+        out("  --entry <entry>                                              Complete workflow path in Dockstore (ex. github.com/collaboratory/seqware-bwa-workflow)");
         out("");
         out("Optional Parameters");
         out("  --descriptor-type <descriptor-type>                          Descriptor type of the given workflow.  Can only be altered if workflow is a STUB.");
@@ -177,7 +177,7 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
         out("");
         out("Required Parameters:");
         out("  --entry <entry>                                      Complete " + getEntryType().toLowerCase()
-            + " path in the Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
+            + " path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
         out("  --name <name>                                        Name of the " + getEntryType().toLowerCase() + " version.");
         out("");
         out("Optional Parameters");
@@ -226,7 +226,7 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
     @Override
     protected void printClientSpecificHelp() {
         out("");
-        out("  manual_publish   :  registers a Github, Gitlab or Bitbucket workflow in the dockstore and then attempts to publish");
+        out("  manual_publish   :  registers a Github, Gitlab or Bitbucket workflow in Dockstore and then attempts to publish");
         out("");
         out("  " + UPDATE_WORKFLOW + "  :  updates certain fields of a workflow");
         out("");
@@ -668,7 +668,7 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
         out("  No arguments will list the current and potential " + getEntryType() + "s to share.");
         out("Required Parameters:");
         out("  --entry <entry>             Complete " + getEntryType()
-            + " path in the Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
+            + " path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
         //TODO add support for optional parameter '--entryname'
         printHelpFooter();
     }
@@ -1050,7 +1050,7 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
         out("  Converts a full, unpublished workflow back to a stub.");
         out("");
         out("Required Parameters:");
-        out("  --entry <entry>                       Complete workflow path in the Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
+        out("  --entry <entry>                       Complete workflow path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
         out("");
         printHelpFooter();
     }
@@ -1092,7 +1092,7 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
 
     @Parameters(separators = "=", commandDescription = "Spit out a json run file for a given entry.")
     private static class CommandEntry2json {
-        @Parameter(names = "--entry", description = "Complete workflow path in the Dockstore (ex. NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq:master)", required = true)
+        @Parameter(names = "--entry", description = "Complete workflow path in Dockstore (ex. NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq:master)", required = true)
         private String entry;
         @Parameter(names = "--help", description = "Prints help for entry2json command", help = true)
         private boolean help = false;
@@ -1100,7 +1100,7 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
 
     @Parameters(separators = "=", commandDescription = "Spit out a tsv run file for a given entry.")
     private static class CommandEntry2tsv {
-        @Parameter(names = "--entry", description = "Complete workflow path in the Dockstore (ex. NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq:master)", required = true)
+        @Parameter(names = "--entry", description = "Complete workflow path in Dockstore (ex. NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq:master)", required = true)
         private String entry;
         @Parameter(names = "--help", description = "Prints help for entry2json command", help = true)
         private boolean help = false;
@@ -1110,11 +1110,11 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
     private static class CommandLaunch {
         @Parameter(names = "--local-entry", description = "Allows you to specify a full path to a local descriptor instead of an entry path")
         private String localEntry;
-        @Parameter(names = "--entry", description = "Complete workflow path in the Dockstore (ex. NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq:master)")
+        @Parameter(names = "--entry", description = "Complete workflow path in Dockstore (ex. NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq:master)")
         private String entry;
-        @Parameter(names = "--json", description = "Parameters to the entry in the dockstore, one map for one run, an array of maps for multiple runs")
+        @Parameter(names = "--json", description = "Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs")
         private String json;
-        @Parameter(names = "--yaml", description = "Parameters to the entry in the dockstore, one map for one run, an array of maps for multiple runs")
+        @Parameter(names = "--yaml", description = "Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs")
         private String yaml;
         @Parameter(names = "--wdl-output-target", description = "Allows you to specify a remote path to provision outputs files to (ex: s3://oicr.temp/testing-launcher/")
         private String wdlOutputTarget;


### PR DESCRIPTION
This PR is meant normalize the client facing mentions of Dockstore from 'the dockstore' in some places to 'Dockstore'. 