### PR TITLE
Regression tests should test with 1.7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+dist: bionic
 services:
 - docker
 
@@ -91,9 +91,4 @@ after_success:
 - java -jar ~/codacy-coverage-reporter-assembly-latest.jar report -l Java -r reports/target/site/jacoco-aggregate/jacoco.xml 
   
 notifications:
-  slack:
-    on_success: never
-    on_failure: always
-    rooms:
-    - oicr:S9k4EowgQv9AnbCfEZHSzCsg
   webhooks: https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class CommonTestUtilities {
 
-    public static final String OLD_DOCKSTORE_VERSION = "1.6.0";
+    public static final String OLD_DOCKSTORE_VERSION = "1.7.4";
     // Travis is slow, need to wait up to 1 min for webservice to return
     public static final int WAIT_TIME = 60000;
     public static final String PUBLIC_CONFIG_PATH = ResourceHelpers.resourceFilePath("dockstore.yml");

--- a/scripts/decrypt.sh
+++ b/scripts/decrypt.sh
@@ -8,7 +8,7 @@ set -o pipefail
 set -o nounset
 set -o xtrace
 
-if [[ "${TESTING_PROFILE}" == "confidential"* ]] || [[ "${TESTING_PROFILE}" == "automated-review" ]]; then
+if [[ "${TESTING_PROFILE}" == "confidential"* ]] || [[ "${TESTING_PROFILE}" == "regression"* ]] || [[ "${TESTING_PROFILE}" == "automated-review" ]]; then
     openssl aes-256-cbc -K $encrypted_04282e75bce6_key -iv $encrypted_04282e75bce6_iv -in secrets.tar.enc -out secrets.tar -d
     tar xvf secrets.tar
     mv dockstore-cli-integration-testing/src/test/resources/dstesting_pcks8.pem /home/travis/dstesting_pcks8.pem


### PR DESCRIPTION
Regression tests are failing in `release/1.8`, looks like they now need confidential data for some reason
Also have .travis.yml pass validation