### PR TITLE
Make test parameter flags required

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/JCommanderUtility.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/JCommanderUtility.java
@@ -51,10 +51,14 @@ public final class JCommanderUtility {
                 + "  --entry <entry>                     Complete workflow path in Dockstore (ex. NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq:master)\n"
                 + "   OR\n"
                 + "  --local-entry <local-entry>         Allows you to specify a full path to a local descriptor instead of an entry path\n");
+        out("");
+        out("  --json <json file>                  Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs");
+        out("   OR");
+        out("  --yaml <yaml file>                  Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs (Only for CWL)");
+        out("   OR");
+        out("  --tsv <tsv file>                    One row corresponds to parameters for one run in the dockstore (Only for CWL)");
+        out("");
         out("Optional parameters:\n"
-                + "  --json <json file>                  Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs\n"
-                + "  --yaml <yaml file>                  Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs\n"
-                + "  --tsv <tsv file>                    One row corresponds to parameters for one run in the dockstore (Only for CWL)\n"
                 + "  --wdl-output-target                 Allows you to specify a remote path to provision output files to ex: s3://oicr.temp/testing-launcher/\n"
                 + "  --uuid                              Allows you to specify a uuid for 3rd party notifications\n");
         printJCommanderHelpFooter();

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/JCommanderUtility.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/JCommanderUtility.java
@@ -54,9 +54,9 @@ public final class JCommanderUtility {
         out("");
         out("  --json <json file>                  Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs");
         out("   OR");
-        out("  --yaml <yaml file>                  Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs (Only for CWL)");
+        out("  --yaml <yaml file>                  Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs (only for CWL)");
         out("   OR");
-        out("  --tsv <tsv file>                    One row corresponds to parameters for one run in the dockstore (Only for CWL)");
+        out("  --tsv <tsv file>                    One row corresponds to parameters for one run in the dockstore (only for CWL)");
         out("");
         out("Optional parameters:\n"
                 + "  --wdl-output-target                 Allows you to specify a remote path to provision output files to ex: s3://oicr.temp/testing-launcher/\n"


### PR DESCRIPTION
For dockstore/dockstore#1971

Clarify that one of the flags are required.  Also mention that only CWL supports YAML