### PR TITLE
use full workflow path when printing workflow list

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/ArgumentUtility.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/ArgumentUtility.java
@@ -180,7 +180,7 @@ public final class ArgumentUtility {
         int[] maxWidths = { NAME_HEADER.length(), DESCRIPTION_HEADER.length(), GIT_HEADER.length() };
 
         for (Workflow workflow : workflows) {
-            final String workflowGitPath = workflow.getPath();
+            final String workflowGitPath = workflow.getFullWorkflowPath();
             if (workflowGitPath != null && workflowGitPath.length() > maxWidths[0]) {
                 maxWidths[0] = workflowGitPath.length();
             }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -125,7 +125,7 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
 
             String description = getCleanedDescription(workflow.getDescription());
 
-            outFormatted(format, workflow.getPath(), description, gitUrl, boolWord(workflow.isIsPublished()));
+            outFormatted(format, workflow.getFullWorkflowPath(), description, gitUrl, boolWord(workflow.isIsPublished()));
         }
     }
 


### PR DESCRIPTION
Main issue: https://github.com/dockstore/dockstore/issues/3605

Original bug report noted confusing duplicate workflow names appearing in search results:
```
$ dockstore workflow search --pattern md5sum
MATCHING WORKFLOWS
---------------------------------------------
NAME                                                             DESCRIPTION                                          GIT REPO                                                                 PUBLISHED
github.com/coverbeck/md5sum-dockstore-yml                                                                             git@github.com:coverbeck/md5sum-dockstore-yml.git                        Yes
github.com/DataBiosphere/toolbox                                 This wraps the md5sum tool with a checker workf...   git@github.com:DataBiosphere/toolbox.git                                 Yes
github.com/DataBiosphere/toolbox                                                                                      git@github.com:DataBiosphere/toolbox.git                                 Yes
github.com/DataBiosphere/toolbox                                 This wraps the md5sum tool with a checker workf...   git@github.com:DataBiosphere/toolbox.git                                 Yes
github.com/DataBiosphere/toolbox                                 Computes the md5sum value of an input CRAM file...   git@github.com:DataBiosphere/toolbox.git                                 Yes
github.com/briandoconnor/dockstore-workflow-md5sum-tester                                                             git@github.com:briandoconnor/dockstore-workflow-md5sum-tester.git        Yes
github.com/dockstore-testing/md5sum-checker                                                                           git@github.com:dockstore-testing/md5sum-checker.git                      Yes
github.com/dockstore-testing/md5sum-checker                                                                           git@github.com:dockstore-testing/md5sum-checker.git                      Yes
github.com/dockstore-testing/md5sum-checker                      This demonstrates how to wrap a "real" tool wit...   git@github.com:dockstore-testing/md5sum-checker.git                      Yes
github.com/dockstore-testing/md5sum-checker                      # md5sum-checkerThese define their own input JS...   git@github.com:dockstore-testing/md5sum-checker.git                      Yes
github.com/dockstore-testing/dockstore-workflow-md5sum-unified                                                        git@github.com:dockstore-testing/dockstore-workflow-md5sum-unified.git   Yes
github.com/dockstore-testing/dockstore-workflow-md5sum-unified                                                        git@github.com:dockstore-testing/dockstore-workflow-md5sum-unified.git   Yes
github.com/dockstore-testing/dockstore-workflow-md5sum-unified   This demonstrates how to wrap a "real" workflow...   git@github.com:dockstore-testing/dockstore-workflow-md5sum-unified.git   Yes
github.com/briandoconnor/dockstore-workflow-md5sum-tester                                                             git@github.com:briandoconnor/dockstore-workflow-md5sum-tester.git        Yes
github.com/briandoconnor/dockstore-workflow-md5sum                                                                    git@github.com:briandoconnor/dockstore-workflow-md5sum.git               Yes
github.com/briandoconnor/dockstore-workflow-md5sum                                                                    git@github.com:briandoconnor/dockstore-workflow-md5sum.git               Yes
```

This turns out to be an issue with printing workflow lists in general as the "NAME" isn't the *full* workflow path:
```
$ dockstore workflow list
NAME                                         DESCRIPTION   GIT REPO                                             PUBLISHED
github.com/GFJHogue/one-workflow-many-ways                 git@github.com:GFJHogue/one-workflow-many-ways.git   Yes
github.com/GFJHogue/one-workflow-many-ways                 git@github.com:GFJHogue/one-workflow-many-ways.git   Yes
```

Switching to using the *full* workflow paths gives the following improved results for the prior 2 examples:
```
$ dockstore workflow search --pattern md5sum
MATCHING WORKFLOWS
---------------------------------------------
NAME                                                                               DESCRIPTION                                          GIT REPO                                                                 PUBLISHED
github.com/coverbeck/md5sum-dockstore-yml/foobar                                                                                        git@github.com:coverbeck/md5sum-dockstore-yml.git                        Yes
github.com/DataBiosphere/toolbox/CRAM_md5sum_cwl_cwl_checker                       This wraps the md5sum tool with a checker workf...   git@github.com:DataBiosphere/toolbox.git                                 Yes
github.com/DataBiosphere/toolbox/CRAM_md5sum_cwl                                                                                        git@github.com:DataBiosphere/toolbox.git                                 Yes
github.com/DataBiosphere/toolbox/CRAM_md5sum_wdl_wdl_checker                       This wraps the md5sum tool with a checker workf...   git@github.com:DataBiosphere/toolbox.git                                 Yes
github.com/DataBiosphere/toolbox/CRAM_md5sum_wdl                                   Computes the md5sum value of an input CRAM file...   git@github.com:DataBiosphere/toolbox.git                                 Yes
github.com/briandoconnor/dockstore-workflow-md5sum-tester/_cwl_checker                                                                  git@github.com:briandoconnor/dockstore-workflow-md5sum-tester.git        Yes
github.com/dockstore-testing/md5sum-checker/wdl_wdl_checker                                                                             git@github.com:dockstore-testing/md5sum-checker.git                      Yes
github.com/dockstore-testing/md5sum-checker/wdl                                                                                         git@github.com:dockstore-testing/md5sum-checker.git                      Yes
github.com/dockstore-testing/md5sum-checker/_cwl_checker                           This demonstrates how to wrap a "real" tool wit...   git@github.com:dockstore-testing/md5sum-checker.git                      Yes
github.com/dockstore-testing/md5sum-checker                                        # md5sum-checkerThese define their own input JS...   git@github.com:dockstore-testing/md5sum-checker.git                      Yes
github.com/dockstore-testing/dockstore-workflow-md5sum-unified/wdl_checker                                                              git@github.com:dockstore-testing/dockstore-workflow-md5sum-unified.git   Yes
github.com/dockstore-testing/dockstore-workflow-md5sum-unified/wdl                                                                      git@github.com:dockstore-testing/dockstore-workflow-md5sum-unified.git   Yes
github.com/dockstore-testing/dockstore-workflow-md5sum-unified/cwl_checker         This demonstrates how to wrap a "real" workflow...   git@github.com:dockstore-testing/dockstore-workflow-md5sum-unified.git   Yes
github.com/briandoconnor/dockstore-workflow-md5sum-tester                                                                               git@github.com:briandoconnor/dockstore-workflow-md5sum-tester.git        Yes
github.com/briandoconnor/dockstore-workflow-md5sum/dockstore-wdl-workflow-md5sum                                                        git@github.com:briandoconnor/dockstore-workflow-md5sum.git               Yes
github.com/briandoconnor/dockstore-workflow-md5sum                                                                                      git@github.com:briandoconnor/dockstore-workflow-md5sum.git               Yes
```
```
$ dockstore workflow list
NAME                                                   DESCRIPTION   GIT REPO                                             PUBLISHED
github.com/GFJHogue/one-workflow-many-ways/bamqc_CWL                 git@github.com:GFJHogue/one-workflow-many-ways.git   Yes
github.com/GFJHogue/one-workflow-many-ways/bamqc_NFL                 git@github.com:GFJHogue/one-workflow-many-ways.git   Yes
```

This also prevents users from attempting to use the short paths from the list in workflow commands, where they should use the full path:
```
$ dockstore workflow refresh --entry github.com/GFJHogue/one-workflow-many-ways
15:43:13.056 [main] ERROR io.dockstore.client.cli.ArgumentUtility - Entry not found
```