### PR TITLE
633/workflow entryname

### DIFF
--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
@@ -1512,11 +1512,9 @@ public class BasicIT extends BaseIT {
         Assert.assertEquals("there should be 1 registered tool", 1, countPublish);
 
         // Unpublish incorrectly
-        systemOutRule.clearLog();
+        systemExit.expectSystemExitWithStatus(Client.COMMAND_ERROR);
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file.txt"), "tool", "publish", "--unpub", "--entry",
             "quay.io/dockstoretestuser/quayandgithub", "--entryname", "fake_tool_name", "--script" });
-        assertTrue("Shouldn't be able to use --unpub and --entryname simultaneously in a command",
-                systemOutRule.getLog().contains("Unable to specify both --unpub and --entryname together."));
 
         final long countBadUnpublish = testingPostgres
             .runSelectStatement("SELECT COUNT(*) FROM tool WHERE toolname = 'fake_tool_name' AND ispublished='t'", long.class);

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
@@ -1503,9 +1503,19 @@ public class BasicIT extends BaseIT {
      */
     @Test
     public void testQuayGithubPublishAndUnpublishAToolnewEntryName() {
+
+        final String publishNameParameter = "--newEntryName";
+
         // Publish
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file.txt"), "tool", "publish", "--entry",
-            "quay.io/dockstoretestuser/quayandgithub", "--newEntryName", "fake_tool_name", "--script" });
+            "quay.io/dockstoretestuser/quayandgithub", publishNameParameter, "fake_tool_name", "--script" });
+
+        // Publish a second time, should fail
+        systemOutRule.clearLog();
+        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file.txt"), "tool", "publish", "--entry",
+            "quay.io/dockstoretestuser/quayandgithub", publishNameParameter, "fake_tool_name", "--script" });
+        assertTrue("Attempting to publish a registered tool should notify the user",
+            systemOutRule.getLog().contains("The following tool is already registered: quay.io/dockstoretestuser/quayandgithub/fake_tool_name"));
 
         final long countPublish = testingPostgres
             .runSelectStatement("SELECT COUNT(*) FROM tool WHERE toolname = 'fake_tool_name' AND ispublished='t'", long.class);
@@ -1514,7 +1524,7 @@ public class BasicIT extends BaseIT {
         // Unpublish incorrectly
         systemExit.expectSystemExitWithStatus(Client.COMMAND_ERROR);
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file.txt"), "tool", "publish", "--unpub", "--entry",
-            "quay.io/dockstoretestuser/quayandgithub", "--newEntryName", "fake_tool_name", "--script" });
+            "quay.io/dockstoretestuser/quayandgithub", publishNameParameter, "fake_tool_name", "--script" });
 
         final long countBadUnpublish = testingPostgres
             .runSelectStatement("SELECT COUNT(*) FROM tool WHERE toolname = 'fake_tool_name' AND ispublished='t'", long.class);
@@ -1525,7 +1535,63 @@ public class BasicIT extends BaseIT {
             "quay.io/dockstoretestuser/quayandgithub/fake_tool_name", "--script" });
 
         final long countGoodUnpublish = testingPostgres
-                .runSelectStatement("SELECT COUNT(*) FROM tool WHERE toolname = 'fake_tool_name' AND ispublished='t'", long.class);
+            .runSelectStatement("SELECT COUNT(*) FROM tool WHERE toolname = 'fake_tool_name' AND ispublished='t'", long.class);
         Assert.assertEquals("there should be 0 registered", 0, countGoodUnpublish);
+
+        // try to unpublish the unpublished tool
+        systemOutRule.clearLog();
+        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file.txt"), "tool", "publish", "--unpub", "--entry",
+            "quay.io/dockstoretestuser/quayandgithub/fake_tool_name", "--script" });
+        assertTrue("Attempting to publish a registered tool should notify the user",
+            systemOutRule.getLog().contains("The following tool is already unpublished: quay.io/dockstoretestuser/quayandgithub/fake_tool_name"));
+    }
+
+    /**
+     * Checks that you can properly publish and unpublish a Quay/Github tool using the --entryname parameter. --entryname is deprecated,
+     * verifying backwards compatibility
+     */
+    @Test
+    public void testQuayGithubPublishAndUnpublishAToolEntryName() {
+
+        final String publishNameParameter = "--entryname";
+
+        // Publish
+        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file.txt"), "tool", "publish", "--entry",
+            "quay.io/dockstoretestuser/quayandgithub", publishNameParameter, "fake_tool_name", "--script" });
+
+        // Publish a second time, should fail
+        systemOutRule.clearLog();
+        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file.txt"), "tool", "publish", "--entry",
+            "quay.io/dockstoretestuser/quayandgithub", publishNameParameter, "fake_tool_name", "--script" });
+        assertTrue("Attempting to publish a registered tool should notify the user",
+            systemOutRule.getLog().contains("The following tool is already registered: quay.io/dockstoretestuser/quayandgithub/fake_tool_name"));
+
+        final long countPublish = testingPostgres
+            .runSelectStatement("SELECT COUNT(*) FROM tool WHERE toolname = 'fake_tool_name' AND ispublished='t'", long.class);
+        Assert.assertEquals("there should be 1 registered tool", 1, countPublish);
+
+        // Unpublish incorrectly
+        systemExit.expectSystemExitWithStatus(Client.COMMAND_ERROR);
+        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file.txt"), "tool", "publish", "--unpub", "--entry",
+            "quay.io/dockstoretestuser/quayandgithub", publishNameParameter, "fake_tool_name", "--script" });
+
+        final long countBadUnpublish = testingPostgres
+            .runSelectStatement("SELECT COUNT(*) FROM tool WHERE toolname = 'fake_tool_name' AND ispublished='t'", long.class);
+        Assert.assertEquals("there should be 1 registered tool after invalid unpublish request", 1, countBadUnpublish);
+
+        // unpublish correctly
+        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file.txt"), "tool", "publish", "--unpub", "--entry",
+            "quay.io/dockstoretestuser/quayandgithub/fake_tool_name", "--script" });
+
+        final long countGoodUnpublish = testingPostgres
+            .runSelectStatement("SELECT COUNT(*) FROM tool WHERE toolname = 'fake_tool_name' AND ispublished='t'", long.class);
+        Assert.assertEquals("there should be 0 registered", 0, countGoodUnpublish);
+
+        // try to unpublish the unpublished tool
+        systemOutRule.clearLog();
+        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file.txt"), "tool", "publish", "--unpub", "--entry",
+            "quay.io/dockstoretestuser/quayandgithub/fake_tool_name", "--script" });
+        assertTrue("Attempting to publish a registered tool should notify the user",
+            systemOutRule.getLog().contains("The following tool is already unpublished: quay.io/dockstoretestuser/quayandgithub/fake_tool_name"));
     }
 }

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
@@ -1499,13 +1499,13 @@ public class BasicIT extends BaseIT {
     }
 
     /**
-     * Checks that you can properly publish and unpublish a Quay/Github tool using the --entryname parameter
+     * Checks that you can properly publish and unpublish a Quay/Github tool using the --newEntryName parameter
      */
     @Test
-    public void testQuayGithubPublishAndUnpublishAToolEntryname() {
+    public void testQuayGithubPublishAndUnpublishAToolnewEntryName() {
         // Publish
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file.txt"), "tool", "publish", "--entry",
-            "quay.io/dockstoretestuser/quayandgithub", "--entryname", "fake_tool_name", "--script" });
+            "quay.io/dockstoretestuser/quayandgithub", "--newEntryName", "fake_tool_name", "--script" });
 
         final long countPublish = testingPostgres
             .runSelectStatement("SELECT COUNT(*) FROM tool WHERE toolname = 'fake_tool_name' AND ispublished='t'", long.class);
@@ -1514,7 +1514,7 @@ public class BasicIT extends BaseIT {
         // Unpublish incorrectly
         systemExit.expectSystemExitWithStatus(Client.COMMAND_ERROR);
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file.txt"), "tool", "publish", "--unpub", "--entry",
-            "quay.io/dockstoretestuser/quayandgithub", "--entryname", "fake_tool_name", "--script" });
+            "quay.io/dockstoretestuser/quayandgithub", "--newEntryName", "fake_tool_name", "--script" });
 
         final long countBadUnpublish = testingPostgres
             .runSelectStatement("SELECT COUNT(*) FROM tool WHERE toolname = 'fake_tool_name' AND ispublished='t'", long.class);

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
@@ -1499,12 +1499,12 @@ public class BasicIT extends BaseIT {
     }
 
     /**
-     * Checks that you can properly publish and unpublish a Quay/Github tool using the --newEntryName parameter
+     * Checks that you can properly publish and unpublish a Quay/Github tool using the --new-entry-name parameter
      */
     @Test
     public void testQuayGithubPublishAndUnpublishAToolnewEntryName() {
 
-        final String publishNameParameter = "--newEntryName";
+        final String publishNameParameter = "--new-entry-name";
 
         // Publish
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file.txt"), "tool", "publish", "--entry",

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -1077,10 +1077,10 @@ public class GeneralWorkflowIT extends BaseIT {
     }
 
     /**
-    * Tests publishing/unpublishing workflows with the --entryname parameter
+    * Tests publishing/unpublishing workflows with the --newEntryName parameter
     */
     @Test
-    public void testPublishWithEntryName() {
+    public void testPublishWithNewEntryName() {
         // register workflow
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "manual_publish", "--repository",
             "parameter_test_workflow", "--organization", "DockstoreTestUser2", "--git-version-control", "github", "--script"});
@@ -1094,7 +1094,7 @@ public class GeneralWorkflowIT extends BaseIT {
         // publish workflow with name 'test_entryname'
         Client.main(
             new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish",
-                "--entry", "github.com/DockstoreTestUser2/parameter_test_workflow", "--entryname", "test_entryname", "--script"});
+                "--entry", "github.com/DockstoreTestUser2/parameter_test_workflow", "--newEntryName", "test_entryname", "--script"});
 
         // verify there are 2 workflows associated with the user
         final long countTotalPublishedWorkflows = testingPostgres
@@ -1111,7 +1111,7 @@ public class GeneralWorkflowIT extends BaseIT {
         // Try unpublishing with both --unpub and --entryname specified, should fail
         systemExit.expectSystemExitWithStatus(Client.COMMAND_ERROR);
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish", "--unpub",
-            "--entry", "github.com/DockstoreTestUser2/parameter_test_workflow", "--entryname", "test_entryname", "--script"});
+            "--entry", "github.com/DockstoreTestUser2/parameter_test_workflow", "--newEntryName", "test_entryname", "--script"});
 
         // unpublish workflow with name 'test_entryname'
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish", "--unpub",

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -1081,6 +1081,9 @@ public class GeneralWorkflowIT extends BaseIT {
     */
     @Test
     public void testPublishWithNewEntryName() {
+
+        final String publishNameParameter = "--newEntryName";
+
         // register workflow
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "manual_publish", "--repository",
             "parameter_test_workflow", "--organization", "DockstoreTestUser2", "--git-version-control", "github", "--script"});
@@ -1094,7 +1097,15 @@ public class GeneralWorkflowIT extends BaseIT {
         // publish workflow with name 'test_entryname'
         Client.main(
             new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish",
-                "--entry", "github.com/DockstoreTestUser2/parameter_test_workflow", "--newEntryName", "test_entryname", "--script"});
+                "--entry", "github.com/DockstoreTestUser2/parameter_test_workflow", publishNameParameter, "test_entryname", "--script"});
+
+        // publish workflow with name 'test_entryname' a second time, shouldn't work
+        systemOutRule.clearLog();
+        Client.main(
+            new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish",
+                "--entry", "github.com/DockstoreTestUser2/parameter_test_workflow", publishNameParameter, "test_entryname", "--script"});
+        assertTrue("Attempting to publish a registered workflow should notify the user",
+            systemOutRule.getLog().contains("The following workflow is already registered: github.com/DockstoreTestUser2/parameter_test_workflow"));
 
         // verify there are 2 workflows associated with the user
         final long countTotalPublishedWorkflows = testingPostgres
@@ -1111,7 +1122,7 @@ public class GeneralWorkflowIT extends BaseIT {
         // Try unpublishing with both --unpub and --entryname specified, should fail
         systemExit.expectSystemExitWithStatus(Client.COMMAND_ERROR);
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish", "--unpub",
-            "--entry", "github.com/DockstoreTestUser2/parameter_test_workflow", "--newEntryName", "test_entryname", "--script"});
+            "--entry", "github.com/DockstoreTestUser2/parameter_test_workflow", publishNameParameter, "test_entryname", "--script"});
 
         // unpublish workflow with name 'test_entryname'
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish", "--unpub",
@@ -1121,5 +1132,77 @@ public class GeneralWorkflowIT extends BaseIT {
         final long countUnpublishedWorkflowWithCustomName = testingPostgres.runSelectStatement(
             "SELECT COUNT(*) FROM workflow WHERE organization='DockstoreTestUser2' AND repository='parameter_test_workflow' AND workflowname='test_entryname' AND ispublished='f';", long.class);
         assertEquals("The workflow should exist and be unpublished", 1, countUnpublishedWorkflowWithCustomName);
+
+        systemOutRule.clearLog();
+        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish", "--unpub",
+            "--entry", "github.com/DockstoreTestUser2/parameter_test_workflow/test_entryname", "--script"});
+        assertTrue("Attempting to publish a registered workflow should notify the user",
+            systemOutRule.getLog().contains("The following workflow is already unpublished: github.com/DockstoreTestUser2/parameter_test_workflow"));
+    }
+
+
+    /**
+     * Tests publishing/unpublishing workflows with the original --entryname parameter to ensure backwards compatibility
+     */
+    @Test
+    public void testPublishWithEntryName() {
+
+        final String publishNameParameter = "--entryname";
+
+        // register workflow
+        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "manual_publish", "--repository",
+            "parameter_test_workflow", "--organization", "DockstoreTestUser2", "--git-version-control", "github", "--script"});
+
+        // count number of workflows for this user with the workflowname 'test_entryname'
+        final long countInitialWorkflowPublish = testingPostgres
+            .runSelectStatement("SELECT COUNT(*) FROM workflow WHERE organization='DockstoreTestUser2' "
+                + "AND repository='parameter_test_workflow' AND workflowname IS NULL;", long.class);
+        assertEquals("The initial workflow should be published without a workflow name", 1, countInitialWorkflowPublish);
+
+        // publish workflow with name 'test_entryname'
+        Client.main(
+            new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish",
+                "--entry", "github.com/DockstoreTestUser2/parameter_test_workflow", publishNameParameter, "test_entryname", "--script"});
+
+        // publish workflow with name 'test_entryname' a second time, shouldn't work
+        systemOutRule.clearLog();
+        Client.main(
+            new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish",
+                "--entry", "github.com/DockstoreTestUser2/parameter_test_workflow", publishNameParameter, "test_entryname", "--script"});
+        assertTrue("Attempting to publish a registered workflow should notify the user",
+            systemOutRule.getLog().contains("The following workflow is already registered: github.com/DockstoreTestUser2/parameter_test_workflow"));
+
+        // verify there are 2 workflows associated with the user
+        final long countTotalPublishedWorkflows = testingPostgres
+            .runSelectStatement("SELECT COUNT(*) FROM workflow WHERE organization='DockstoreTestUser2' "
+                        + "AND repository='parameter_test_workflow' AND ispublished='t';", long.class);
+        assertEquals("Ensure there are 2 published workflows", 2, countTotalPublishedWorkflows);
+
+        // verify count of number of published workflows, with the desired name, is 1
+        final long countPublishedWorkflowWithCustomName = testingPostgres
+            .runSelectStatement("SELECT COUNT(*) FROM workflow WHERE organization='DockstoreTestUser2' "
+                        + "AND repository='parameter_test_workflow' AND workflowname='test_entryname' AND ispublished='t';", long.class);
+        assertEquals("Ensure there is a published workflow with the expected workflow name", 1, countPublishedWorkflowWithCustomName);
+
+        // Try unpublishing with both --unpub and --entryname specified, should fail
+        systemExit.expectSystemExitWithStatus(Client.COMMAND_ERROR);
+        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish", "--unpub",
+            "--entry", "github.com/DockstoreTestUser2/parameter_test_workflow", publishNameParameter, "test_entryname", "--script"});
+
+        // unpublish workflow with name 'test_entryname'
+        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish", "--unpub",
+            "--entry", "github.com/DockstoreTestUser2/parameter_test_workflow/test_entryname", "--script"});
+
+        // verify count of number of unpublish workflows with the desired name is 1
+        final long countUnpublishedWorkflowWithCustomName = testingPostgres.runSelectStatement(
+            "SELECT COUNT(*) FROM workflow WHERE organization='DockstoreTestUser2' AND repository='parameter_test_workflow' AND workflowname='test_entryname' AND ispublished='f';", long.class);
+        assertEquals("The workflow should exist and be unpublished", 1, countUnpublishedWorkflowWithCustomName);
+
+        systemOutRule.clearLog();
+        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish", "--unpub",
+            "--entry", "github.com/DockstoreTestUser2/parameter_test_workflow/test_entryname", "--script"});
+        assertTrue("Attempting to publish a registered workflow should notify the user",
+            systemOutRule.getLog().contains("The following workflow is already unpublished: github.com/DockstoreTestUser2/parameter_test_workflow"));
+
     }
 }

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -1109,11 +1109,9 @@ public class GeneralWorkflowIT extends BaseIT {
         assertEquals("Ensure there is a published workflow with the expected workflow name", 1, countPublishedWorkflowWithCustomName);
 
         // Try unpublishing with both --unpub and --entryname specified, should fail
-        systemOutRule.clearLog();
+        systemExit.expectSystemExitWithStatus(Client.COMMAND_ERROR);
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish", "--unpub",
             "--entry", "github.com/DockstoreTestUser2/parameter_test_workflow", "--entryname", "test_entryname", "--script"});
-        assertTrue("Shouldn't be able to use --unpub and --entryname simultaneously in a command",
-            systemOutRule.getLog().contains("Unable to specify both --unpub and --entryname together."));
 
         // unpublish workflow with name 'test_entryname'
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish", "--unpub",

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -1077,12 +1077,12 @@ public class GeneralWorkflowIT extends BaseIT {
     }
 
     /**
-    * Tests publishing/unpublishing workflows with the --newEntryName parameter
+    * Tests publishing/unpublishing workflows with the --new-entry-name parameter
     */
     @Test
     public void testPublishWithNewEntryName() {
 
-        final String publishNameParameter = "--newEntryName";
+        final String publishNameParameter = "--new-entry-name";
 
         // register workflow
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "manual_publish", "--repository",

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -1076,6 +1076,9 @@ public class GeneralWorkflowIT extends BaseIT {
 
     }
 
+    /**
+    * Tests publishing/unpublishing workflows with the --entryname parameter
+    */
     @Test
     public void testPublishWithEntryName() {
         // register workflow
@@ -1104,6 +1107,13 @@ public class GeneralWorkflowIT extends BaseIT {
             .runSelectStatement("SELECT COUNT(*) FROM workflow WHERE organization='DockstoreTestUser2' "
                 + "AND repository='parameter_test_workflow' AND workflowname='test_entryname' AND ispublished='t';", long.class);
         assertEquals("Ensure there is a published workflow with the expected workflow name", 1, countPublishedWorkflowWithCustomName);
+
+        // Try unpublishing with both --unpub and --entryname specified, should fail
+        systemOutRule.clearLog();
+        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish", "--unpub",
+            "--entry", "github.com/DockstoreTestUser2/parameter_test_workflow", "--entryname", "test_entryname", "--script"});
+        assertTrue("Shouldn't be able to use --unpub and --entryname simultaneously in a command",
+            systemOutRule.getLog().contains("Unable to specify both --unpub and --entryname together."));
 
         // unpublish workflow with name 'test_entryname'
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish", "--unpub",

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -85,6 +85,7 @@ import static io.dockstore.client.cli.ArgumentUtility.DOWNLOAD;
 import static io.dockstore.client.cli.ArgumentUtility.LAUNCH;
 import static io.dockstore.client.cli.ArgumentUtility.MAX_DESCRIPTION;
 import static io.dockstore.client.cli.ArgumentUtility.containsHelpRequest;
+import static io.dockstore.client.cli.ArgumentUtility.err;
 import static io.dockstore.client.cli.ArgumentUtility.errorMessage;
 import static io.dockstore.client.cli.ArgumentUtility.exceptionMessage;
 import static io.dockstore.client.cli.ArgumentUtility.invalid;
@@ -454,7 +455,8 @@ public abstract class AbstractEntryClient<T> {
 
             // --newEntryName is the desired parameter flag, but maintaining backwards compatibility for --entryname
             String newEntryName = optVal(args, "--newEntryName", null);
-            if (newEntryName == null) {
+            if (newEntryName == null && args.contains("--entryname")) {
+                err("Dockstore CLI has deprecated the --entryname parameter and may remove it without warning. Please use --newEntryName instead.");
                 newEntryName = optVal(args, "--entryname", null);
             }
 

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -451,7 +451,14 @@ public abstract class AbstractEntryClient<T> {
             String first = reqVal(args, "--entry");
             String entryname = optVal(args, "--entryname", null);
             final boolean unpublishRequest = args.contains("--unpub");
-            handlePublishUnpublish(first, entryname, unpublishRequest);
+
+            // prevent specifying --unpub and --entryname together
+            if (unpublishRequest && entryname != null) {
+                out("Unable to specify both --unpub and --entryname together. If trying to unpublish an entry,"
+                    + " provide the entire entry path under the --entry parameter.");
+            } else {
+                handlePublishUnpublish(first, entryname, unpublishRequest);
+            }
         }
     }
 

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -99,6 +99,7 @@ import static io.dockstore.client.cli.ArgumentUtility.printUsageHelp;
 import static io.dockstore.client.cli.ArgumentUtility.reqVal;
 import static io.dockstore.client.cli.Client.API_ERROR;
 import static io.dockstore.client.cli.Client.CLIENT_ERROR;
+import static io.dockstore.client.cli.Client.COMMAND_ERROR;
 import static io.dockstore.client.cli.Client.ENTRY_NOT_FOUND;
 import static io.dockstore.client.cli.Client.IO_ERROR;
 import static io.dockstore.common.DescriptorLanguage.CWL;
@@ -454,8 +455,8 @@ public abstract class AbstractEntryClient<T> {
 
             // prevent specifying --unpub and --entryname together
             if (unpublishRequest && entryname != null) {
-                out("Unable to specify both --unpub and --entryname together. If trying to unpublish an entry,"
-                    + " provide the entire entry path under the --entry parameter.");
+                errorMessage("Unable to specify both --unpub and --entryname together. If trying to unpublish an entry,"
+                    + " provide the entire entry path under the --entry parameter.", COMMAND_ERROR);
             } else {
                 handlePublishUnpublish(first, entryname, unpublishRequest);
             }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -450,15 +450,20 @@ public abstract class AbstractEntryClient<T> {
             publishHelp();
         } else {
             String first = reqVal(args, "--entry");
-            String entryname = optVal(args, "--entryname", null);
             final boolean unpublishRequest = args.contains("--unpub");
 
+            // --newEntryName is the desired parameter flag, but maintaining backwards compatibility for --entryname
+            String newEntryName = optVal(args, "--newEntryName", null);
+            if (newEntryName == null) {
+                newEntryName = optVal(args, "--entryname", null);
+            }
+
             // prevent specifying --unpub and --entryname together
-            if (unpublishRequest && entryname != null) {
-                errorMessage("Unable to specify both --unpub and --entryname together. If trying to unpublish an entry,"
+            if (unpublishRequest && newEntryName != null) {
+                errorMessage("Unable to specify both --unpub and --newEntryName together. If trying to unpublish an entry,"
                     + " provide the entire entry path under the --entry parameter.", COMMAND_ERROR);
             } else {
-                handlePublishUnpublish(first, entryname, unpublishRequest);
+                handlePublishUnpublish(first, newEntryName, unpublishRequest);
             }
         }
     }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -453,16 +453,16 @@ public abstract class AbstractEntryClient<T> {
             String first = reqVal(args, "--entry");
             final boolean unpublishRequest = args.contains("--unpub");
 
-            // --newEntryName is the desired parameter flag, but maintaining backwards compatibility for --entryname
-            String newEntryName = optVal(args, "--newEntryName", null);
+            // --new-entry-name is the desired parameter flag, but maintaining backwards compatibility for --entryname
+            String newEntryName = optVal(args, "--new-entry-name", null);
             if (newEntryName == null && args.contains("--entryname")) {
-                err("Dockstore CLI has deprecated the --entryname parameter and may remove it without warning. Please use --newEntryName instead.");
+                err("Dockstore CLI has deprecated the --entryname parameter and may remove it without warning. Please use --new-entry-name instead.");
                 newEntryName = optVal(args, "--entryname", null);
             }
 
             // prevent specifying --unpub and --entryname together
             if (unpublishRequest && newEntryName != null) {
-                errorMessage("Unable to specify both --unpub and --newEntryName together. If trying to unpublish an entry,"
+                errorMessage("Unable to specify both --unpub and --new-entry-name together. If trying to unpublish an entry,"
                     + " provide the entire entry path under the --entry parameter.", COMMAND_ERROR);
             } else {
                 handlePublishUnpublish(first, newEntryName, unpublishRequest);

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
@@ -71,7 +71,6 @@ import static io.dockstore.client.cli.ArgumentUtility.printHelpFooter;
 import static io.dockstore.client.cli.ArgumentUtility.printHelpHeader;
 import static io.dockstore.client.cli.ArgumentUtility.printLineBreak;
 import static io.dockstore.client.cli.ArgumentUtility.reqVal;
-import static io.dockstore.client.cli.Client.COMMAND_ERROR;
 import static io.swagger.client.model.DockstoreTool.ModeEnum.HOSTED;
 
 /**
@@ -224,10 +223,6 @@ public class ToolClient extends AbstractEntryClient<DockstoreTool> {
             exceptionMessage(ex, "Unable to " + (unpublishRequest ? "unpublish " : "publish ") + entryPath, Client.API_ERROR);
         }
 
-        if (existingTool == null) {
-            errorMessage("Unable to locate " + entryPath, COMMAND_ERROR);
-        }
-
         if (unpublishRequest) {
             if (isPublished) {
                 publish(false, entryPath);
@@ -262,18 +257,15 @@ public class ToolClient extends AbstractEntryClient<DockstoreTool> {
 
                     newContainer = containersApi.registerManual(newContainer);
 
-                    if (newContainer != null) {
-                        out("Successfully registered " + entryPath + "/" + newName);
-                        containersApi.refresh(newContainer.getId());
-                        publish(true, newContainer.getToolPath());
-                    } else {
-                        errorMessage("Unable to publish " + newName, Client.COMMAND_ERROR);
-                    }
+                    out("Successfully registered " + entryPath + "/" + newName);
+
+                    containersApi.refresh(newContainer.getId());
+                    publish(true, newContainer.getToolPath());
                 } catch (ApiException ex) {
                     exceptionMessage(ex, "Unable to publish " + newName, Client.API_ERROR);
                 }
             } else {
-                out("The following tool is already published: " + entryPath + "/" + newName);
+                out("The following tool is already registered: " + entryPath + "/" + newName);
             }
         }
     }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
@@ -302,7 +302,7 @@ public class ToolClient extends AbstractEntryClient<DockstoreTool> {
         out("  --entry <entry>             Complete " + getEntryType()
                 + " path in the Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
         out("Optional Parameter(s):");
-        out("  --entryname <New" + getEntryType() + "name>      " + "New name to give the tool specified by --entry. "
+        out("  --newEntryName <New" + getEntryType() + "name>      " + "New name to give the tool specified by --entry. "
                 + "This will register and publish a new copy of the tool with the given name.");
         printHelpFooter();
     }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
@@ -294,7 +294,7 @@ public class ToolClient extends AbstractEntryClient<DockstoreTool> {
         out("  --entry <entry>             Complete " + getEntryType()
                 + " path in the Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
         out("Optional Parameter(s):");
-        out("  --newEntryName <New" + getEntryType() + "name>      " + "New name to give the tool specified by --entry. "
+        out("  --new-entry-name <new-tool-name>      " + "New name to give the tool specified by --entry. "
                 + "This will register and publish a new copy of the tool with the given name.");
         printHelpFooter();
     }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -655,10 +655,6 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
             exceptionMessage(ex, "Unable to " + (unpublishRequest ? "unpublish " : "publish ") + entryPath, Client.API_ERROR);
         }
 
-        if (existingWorkflow == null) {
-            errorMessage("Unable to locate " + entryPath, COMMAND_ERROR);
-        }
-
         if (unpublishRequest) {
             if (isPublished) {
                 publish(false, entryPath);
@@ -676,28 +672,25 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
                 try {
                     // path should be represented as repository organization and name (ex. dockstore/dockstore-ui2)
                     final Workflow newWorkflow = workflowsApi.manualRegister(
-                            getGitRegistry(existingWorkflow.getGitUrl()),
-                            existingWorkflow.getOrganization() + "/" + existingWorkflow.getRepository(),
-                            existingWorkflow.getWorkflowPath(),
-                            newName,
-                            existingWorkflow.getDescriptorType().toString(),
-                            existingWorkflow.getDefaultTestParameterFilePath()
+                        getGitRegistry(existingWorkflow.getGitUrl()),
+                        existingWorkflow.getOrganization() + "/" + existingWorkflow.getRepository(),
+                        existingWorkflow.getWorkflowPath(),
+                        newName,
+                        existingWorkflow.getDescriptorType().toString(),
+                        existingWorkflow.getDefaultTestParameterFilePath()
                     );
 
                     final String completeEntryPath = entryPath + "/" + newName;
 
-                    if (newWorkflow != null) {
-                        out("Successfully registered " + completeEntryPath);
-                        workflowsApi.refresh(newWorkflow.getId());
-                        publish(true, completeEntryPath);
-                    } else {
-                        errorMessage("Unable to publish " + completeEntryPath, COMMAND_ERROR);
-                    }
+                    out("Successfully registered " + completeEntryPath);
+
+                    workflowsApi.refresh(newWorkflow.getId());
+                    publish(true, completeEntryPath);
                 } catch (ApiException ex) {
                     exceptionMessage(ex, "Unable to publish " + entryPath + "/" + newName, Client.API_ERROR);
                 }
             } else {
-                out("The following workflow is already published: " + entryPath + "/" + newName);
+                out("The following workflow is already registered: " + entryPath + "/" + newName);
             }
         }
     }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -664,31 +664,17 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
                     publish(true, entryPath);
                 }
             } else {
-                //for workflows method currently doesn't work with --entryname flag
-//                errorMessage("Parameter '--entryname' not valid for workflows. See `workflow publish --help` for more information.",
-//                    CLIENT_ERROR);
                 try {
                     final Workflow workflow = workflowsApi.getWorkflowByPath(entryPath, null, false);
-//                    workflow.setWorkflowName(newName);
-//                    Workflow updatedWorkflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
-//                    final String temp = workflow.getGitUrl();
 
-                    //Workflow newWorkflow = new Workflow();
-                    String registry = getGitRegistry(workflow.getGitUrl());
-
-                    // repository organization and name (ex. dockstore/dockstore-ui2)
-                    String path = workflow.getOrganization() + "/" + workflow.getRepository();
-                    String workflowPath = workflow.getWorkflowPath();
-                    String descriptor = workflow.getDescriptorType().toString();
-                    String testParam = workflow.getDefaultTestParameterFilePath();
-
+                    // path should be represented as repository organization and name (ex. dockstore/dockstore-ui2)
                     final Workflow newWorkflow = workflowsApi.manualRegister(
-                            registry,
-                            path,
-                            workflowPath,
+                            getGitRegistry(workflow.getGitUrl()),
+                            workflow.getOrganization() + "/" + workflow.getRepository(),
+                            workflow.getWorkflowPath(),
                             newName,
-                            descriptor,
-                            testParam
+                            workflow.getDescriptorType().toString(),
+                            workflow.getDefaultTestParameterFilePath()
                     );
 
                     if (newWorkflow != null) {

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -726,7 +726,7 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
         out("  --entry <entry>                      Complete " + getEntryType()
             + " path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
         out("Optional Parameters:");
-        out("  --entryname <newWorflowName>         New name to give the workflow specified by --entry. This will register and publish a new copy of the workflow with the given name.");
+        out("  --newEntryName <newWorflowName>         New name to give the workflow specified by --entry. This will register and publish a new copy of the workflow with the given name.");
         printHelpFooter();
     }
 

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -705,6 +705,9 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
         out("Required Parameters:");
         out("  --entry <entry>             Complete " + getEntryType()
             + " path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
+        out("Optional Parameters:");
+        out("  --entryname <entryname>     Extension to the " + getEntryType()
+                + " path in Dockstore, helpful if multiple workflows are published from the same repository (ex. quay.io/collaboratory/seqware-bwa-workflow/entryname)");
         //TODO add support for optional parameter '--entryname'
         printHelpFooter();
     }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -719,7 +719,7 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
         out("  --entry <entry>                      Complete " + getEntryType()
             + " path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
         out("Optional Parameters:");
-        out("  --newEntryName <newWorflowName>         New name to give the workflow specified by --entry. This will register and publish a new copy of the workflow with the given name.");
+        out("  --new-entry-name <new-workflow-name>         New name to give the workflow specified by --entry. This will register and publish a new copy of the workflow with the given name.");
         printHelpFooter();
     }
 


### PR DESCRIPTION
Github Issue: dockstore/dockstore#2309

The user can specify a custom name for a workflow with the '--entryname' parameter when publishing the workflow from the CLI. This will create a separate workflow entry from the default registered workflow.