### PR TITLE
Copy from CromwellIT tests from dockstore/dockstore

### DIFF
--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/CromwellIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/CromwellIT.java
@@ -104,7 +104,7 @@ public class CromwellIT {
         WdlBridge wdlBridge = new WdlBridge();
         Map<String, String> wdlInputs = null;
         try {
-            wdlInputs = wdlBridge.getInputFiles(workflowFile.getAbsolutePath());
+            wdlInputs = wdlBridge.getInputFiles(workflowFile.getAbsolutePath(), "/wdlfileprov.wdl");
         } catch (WdlParser.SyntaxError ex) {
             Assert.fail("Should not have any issue parsing file");
         }


### PR DESCRIPTION
Part 1 of 2 for preliminary investigation to https://ucsc-cgl.atlassian.net/browse/SEAB-2622

Part 2: https://github.com/dockstore/dockstore/pull/4130

First step is to move client tests back to client (assuming dockstore/dockstore's test is "correct"). This allows for easier debugging (more info than "System Exit(3)")