### PR TITLE
Previous singularity download URL broke, updating URL and version

### DIFF
--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -42,10 +42,10 @@ if [ "${TESTING_PROFILE}" = "singularity-tests" ]; then
 
     # Download and install singularity from a release
     # https://sylabs.io/guides/3.0/user-guide/installation.html#download-and-install-singularity-from-a-release
-    export VERSION=3.7.1 && # adjust this as necessary \
+    export VERSION=3.7.3 && # adjust this as necessary \
     mkdir -p "${SINGULARITY_PATH}"/src/github.com/sylabs && \
     cd "${SINGULARITY_PATH}"/src/github.com/sylabs && \
-    wget https://github.com/sylabs/singularity/releases/download/v"${VERSION}"/singularity-"${VERSION}".tar.gz && \
+    wget https://github.com/sylabs/singularity/archive/refs/tags/v"${VERSION}".tar.gz && \
     tar -xzf singularity-"${VERSION}".tar.gz && \
     cd ./singularity && \
     ./mconfig

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -46,8 +46,8 @@ if [ "${TESTING_PROFILE}" = "singularity-tests" ]; then
     mkdir -p "${SINGULARITY_PATH}"/src/github.com/sylabs && \
     cd "${SINGULARITY_PATH}"/src/github.com/sylabs && \
     wget https://github.com/sylabs/singularity/archive/refs/tags/v"${VERSION}".tar.gz && \
-    tar -xzf singularity-"${VERSION}".tar.gz && \
-    cd ./singularity && \
+    tar -xzf v"${VERSION}".tar.gz && \
+    cd ./singularity-"${VERSION}" && \
     ./mconfig
 
     # Compile singularity


### PR DESCRIPTION
The old singularity URL broke (not sure why): https://github.com/sylabs/singularity/releases/download/v3.7.1/singularity-3.7.1.tar.gz causing the CLI circleCI [tests to fail](https://app.circleci.com/pipelines/github/dockstore/dockstore-cli/527/workflows/19a8d824-7083-4fdc-8c6b-e300388627ee/jobs/990). 
Updated the download url to: https://github.com/sylabs/singularity/archive/refs/tags/v3.7.1.tar.gz.

Per request, also updating the singularity version from 3.7.1 -> 3.7.3 while I'm here.
