### PR TITLE
Service-info endpoint support for WES

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -67,6 +67,7 @@ import io.openapi.wes.client.api.WorkflowExecutionServiceApi;
 import io.openapi.wes.client.model.RunId;
 import io.openapi.wes.client.model.RunLog;
 import io.openapi.wes.client.model.RunStatus;
+import io.openapi.wes.client.model.ServiceInfo;
 import io.swagger.client.ApiException;
 import io.swagger.client.model.Label;
 import io.swagger.client.model.SourceFile;
@@ -1155,6 +1156,19 @@ public abstract class AbstractEntryClient<T> {
                     }
                 }
                 break;
+            case "service-info":
+                if (containsHelpRequest(args)) {
+                    wesServiceInfoHelp();
+                } else {
+                    WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi = getWorkflowExecutionServiceApi(getWesUri(), getWesAuth());
+                    try {
+                        ServiceInfo response = clientWorkflowExecutionServiceApi.getServiceInfo();
+                        out("WES server info: " + response.toString());
+                    } catch (io.openapi.wes.client.ApiException e) {
+                        LOG.error("Error getting WES server info", e);
+                    }
+                }
+                break;
             default:
                 invalid(cmd);
                 break;
@@ -1425,6 +1439,17 @@ public abstract class AbstractEntryClient<T> {
         out("Required Parameters:");
         out("  --id <id>                           Id of a run at the WES endpoint, e.g. id returned from the launch command");
         out("");
+        printWesHelpFooter();
+        printHelpFooter();
+    }
+
+    private void wesServiceInfoHelp() {
+        printHelpHeader();
+        out("Usage: dockstore " + getEntryType().toLowerCase() + " wes service-info --help");
+        out("       dockstore " + getEntryType().toLowerCase() + " wes service-info");
+        out("");
+        out("Description:");
+        out("  Returns descriptive information of the provided WES server. ");
         printWesHelpFooter();
         printHelpFooter();
     }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -1381,6 +1381,7 @@ public abstract class AbstractEntryClient<T> {
         out("       dockstore " + getEntryType().toLowerCase() + " wes launch [parameters]");
         out("       dockstore " + getEntryType().toLowerCase() + " wes status [parameters]");
         out("       dockstore " + getEntryType().toLowerCase() + " wes cancel [parameters]");
+        out("       dockstore " + getEntryType().toLowerCase() + " wes service-info [parameters]");
         out("");
         out("Description:");
         out(" Sends a request to a Workflow Execution Service (WES) endpoint.");

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/AbstractEntryClientTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/AbstractEntryClientTestIT.java
@@ -1,0 +1,43 @@
+package io.dockstore.client.cli;
+
+import io.dropwizard.testing.ResourceHelpers;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
+
+public class AbstractEntryClientTestIT {
+    
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog();
+    @Rule
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+
+    /**
+     *
+     */
+    @Test
+    public void testWESHelpMessages() {
+        String clientConfig = ResourceHelpers.resourceFilePath("clientConfig");
+        String[] command = { "workflow", "wes", "--help", "--config", clientConfig };
+        Client.main(command);
+        Assert.assertTrue("There are unexpected error logs", systemErrRule.getLog().isBlank());
+
+        String[] commandLaunch = { "workflow", "wes", "launch", "--help", "--config", clientConfig };
+        Client.main(commandLaunch);
+        Assert.assertTrue("There are unexpected error logs", systemErrRule.getLog().isBlank());
+
+        String[] commandStatus = { "workflow", "wes", "status", "--help", "--config", clientConfig };
+        Client.main(commandStatus);
+        Assert.assertTrue("There are unexpected error logs", systemErrRule.getLog().isBlank());
+
+        String[] commandCancel = { "workflow", "wes", "cancel", "--help", "--config", clientConfig };
+        Client.main(commandCancel);
+        Assert.assertTrue("There are unexpected error logs", systemErrRule.getLog().isBlank());
+
+        String[] commandServiceInfo = { "workflow", "wes", "service-info", "--help", "--config", clientConfig };
+        Client.main(commandServiceInfo);
+        Assert.assertTrue("There are unexpected error logs", systemErrRule.getLog().isBlank());
+    }
+}

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/AbstractEntryClientTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/AbstractEntryClientTestIT.java
@@ -8,7 +8,7 @@ import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 
 public class AbstractEntryClientTestIT {
-    
+
     @Rule
     public final SystemErrRule systemErrRule = new SystemErrRule().enableLog();
     @Rule
@@ -19,25 +19,20 @@ public class AbstractEntryClientTestIT {
      */
     @Test
     public void testWESHelpMessages() {
-        String clientConfig = ResourceHelpers.resourceFilePath("clientConfig");
-        String[] command = { "workflow", "wes", "--help", "--config", clientConfig };
-        Client.main(command);
-        Assert.assertTrue("There are unexpected error logs", systemErrRule.getLog().isBlank());
+        final String clientConfig = ResourceHelpers.resourceFilePath("clientConfig");
+        final String[] commandNames = {"", "launch", "status", "cancel", "service-info"};
 
-        String[] commandLaunch = { "workflow", "wes", "launch", "--help", "--config", clientConfig };
-        Client.main(commandLaunch);
-        Assert.assertTrue("There are unexpected error logs", systemErrRule.getLog().isBlank());
+        for (String command : commandNames) {
+            String[] commandStatement;
 
-        String[] commandStatus = { "workflow", "wes", "status", "--help", "--config", clientConfig };
-        Client.main(commandStatus);
-        Assert.assertTrue("There are unexpected error logs", systemErrRule.getLog().isBlank());
+            if (command.length() == 0) {
+                commandStatement = new String[]{ "workflow", "wes", "--help", "--config", clientConfig };
+            } else {
+                commandStatement = new String[]{ "workflow", "wes", command, "--help", "--config", clientConfig };
+            }
 
-        String[] commandCancel = { "workflow", "wes", "cancel", "--help", "--config", clientConfig };
-        Client.main(commandCancel);
-        Assert.assertTrue("There are unexpected error logs", systemErrRule.getLog().isBlank());
-
-        String[] commandServiceInfo = { "workflow", "wes", "service-info", "--help", "--config", clientConfig };
-        Client.main(commandServiceInfo);
-        Assert.assertTrue("There are unexpected error logs", systemErrRule.getLog().isBlank());
+            Client.main(commandStatement);
+            Assert.assertTrue("There are unexpected error logs", systemErrRule.getLog().isBlank());
+        }
     }
 }


### PR DESCRIPTION
Adds support for the `/service-info` WES endpoint (https://ga4gh.github.io/workflow-execution-service-schemas/docs/#operation/GetServiceInfo). This will make testing initial AGC work easier. 

Command: `dockstore workflow wes service-info`

The Dockstore-cli help command looks like:
![Screen Shot 2021-10-01 at 12 06 53 PM](https://user-images.githubusercontent.com/36607471/135654232-93ae58d2-ed53-4115-9729-4cc1744a7c17.png)

And the response printed looks like: 
![Screen Shot 2021-10-01 at 12 06 22 PM](https://user-images.githubusercontent.com/36607471/135654267-822928bc-2e17-479c-ad62-95b5c843589b.png)
or
![Screen Shot 2021-10-01 at 1 51 50 PM](https://user-images.githubusercontent.com/36607471/135665305-19f3953c-4c6d-4b14-92f1-5999205d056a.png)


(Note: the null responses are dependent on what the WES endpoint provides, and the generated ServiceInfo class explicitly prints `class ServiceInfo` as part of the info dump, which seems odd.) 
