### PR TITLE
Feature/cli help commands

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -1063,6 +1063,10 @@ public abstract class AbstractEntryClient<T> {
         return clientWorkflowExecutionServiceApi;
     }
 
+    private boolean shouldDisplayHelp(final List<String> args) {
+        return args.isEmpty() || containsHelpRequest(args);
+    }
+
     /**
      * Processes Workflow Execution Schema (WES) commands.
      *
@@ -1072,11 +1076,14 @@ public abstract class AbstractEntryClient<T> {
         if (args.isEmpty() || (args.size() == 1 && containsHelpRequest(args))) {
             wesHelp();
         } else {
-            this.wesRequestData = this.aggregateWesRequestData(args);
+            // only parse credentials if this isn't a help command
+            if (!shouldDisplayHelp(args)) {
+                this.wesRequestData = this.aggregateWesRequestData(args);
+            }
             final String cmd = args.remove(0);
             switch (cmd) {
             case "launch":
-                if (args.isEmpty() || containsHelpRequest(args)) {
+                if (shouldDisplayHelp(args)) {
                     wesLaunchHelp();
                 } else {
                     if (args.contains("--local-entry")) {
@@ -1087,7 +1094,7 @@ public abstract class AbstractEntryClient<T> {
                 }
                 break;
             case "status":
-                if (args.isEmpty() || containsHelpRequest(args)) {
+                if (shouldDisplayHelp(args)) {
                     wesStatusHelp();
                 } else {
                     WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi = getWorkflowExecutionServiceApi();
@@ -1111,7 +1118,7 @@ public abstract class AbstractEntryClient<T> {
                 }
                 break;
             case "cancel":
-                if (args.isEmpty() || containsHelpRequest(args)) {
+                if (shouldDisplayHelp(args)) {
                     wesCancelHelp();
                 } else {
                     WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi = getWorkflowExecutionServiceApi();
@@ -1126,7 +1133,7 @@ public abstract class AbstractEntryClient<T> {
                 }
                 break;
             case "service-info":
-                if (containsHelpRequest(args)) {
+                if (shouldDisplayHelp(args)) {
                     wesServiceInfoHelp();
                 } else {
                     WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi = getWorkflowExecutionServiceApi();

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/AbstractEntryClientTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/AbstractEntryClientTestIT.java
@@ -48,6 +48,7 @@ public class AbstractEntryClientTestIT {
         final String clientConfig = ResourceHelpers.resourceFilePath("clientConfig");
         final String[] commandNames = {"", "launch", "status", "cancel", "service-info"};
 
+        // has config file
         for (String command : commandNames) {
             String[] commandStatement;
 
@@ -55,6 +56,20 @@ public class AbstractEntryClientTestIT {
                 commandStatement = new String[]{ "workflow", "wes", "--help", "--config", clientConfig };
             } else {
                 commandStatement = new String[]{ "workflow", "wes", command, "--help", "--config", clientConfig };
+            }
+
+            Client.main(commandStatement);
+            assertTrue("There are unexpected error logs", systemErrRule.getLog().isBlank());
+        }
+
+        // No config file
+        for (String command : commandNames) {
+            String[] commandStatement;
+
+            if (command.length() == 0) {
+                commandStatement = new String[]{ "workflow", "wes", "--help"};
+            } else {
+                commandStatement = new String[]{ "workflow", "wes", command, "--help"};
             }
 
             Client.main(commandStatement);


### PR DESCRIPTION
During a demo of the new WES CLI features, the command `dockstore workflow wes service-info --help` failed. This was due to the command parser searching for user credentials prior to determining if the command was a help command (which shouldn't require credentials), when no credentials were located, the command displayed an error. 

This PR addresses this issue by having the command parser first check if the command is a help command before running anything else. I also took the opportunity to refactor and make things a little cleaner.

This wasn't hit by the help command tests as they all had a config file containing credentials passed in. More tests were added to improve coverage.
