### PR TITLE
Enforce that we do not introduce any code incompatible with Java 17 LTS

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,25 @@
+name: Java CI
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      # Step that does that actual cache save and restore
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+           ${{ runner.os }}-maven-
+      - name: Get latest snapshot version
+        run: echo 'LATEST_VERSION='$(curl "https://artifacts.oicr.on.ca/artifactory/api/search/latestVersion?g=io.dockstore&a=dockstore&repos=collab-snapshot&v=*" | cut -d '-' -f 1,2) >> $GITHUB_ENV
+      - name: Build with mvnw
+        run: ./mvnw clean test -Punit-tests -Ddockstore-core.version=${{ env.LATEST_VERSION }}-SNAPSHOT -B -ntp -U
+      - name: Check what changed
+        run: git diff

--- a/.github/workflows/mvnw.yml
+++ b/.github/workflows/mvnw.yml
@@ -1,15 +1,27 @@
 name: Java CI
 
-on:
-  schedule:
-    - cron: '0 4 * * *'
+on: [push]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '11', '17' ]
 
     steps:
+      - name: install git secrets
+        run: |
+            wget --no-verbose -O git-secrets-1.3.0.tar.gz https://github.com/awslabs/git-secrets/archive/1.3.0.tar.gz
+            tar -zxf git-secrets-1.3.0.tar.gz
+            cd git-secrets-1.3.0
+            sudo make install   
       - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
       # Step that does that actual cache save and restore
       - uses: actions/cache@v1
         with:
@@ -17,9 +29,5 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
            ${{ runner.os }}-maven-
-      - name: Get latest snapshot version
-        run: echo 'LATEST_VERSION='$(curl "https://artifacts.oicr.on.ca/artifactory/api/search/latestVersion?g=io.dockstore&a=dockstore&repos=collab-snapshot&v=*" | cut -d '-' -f 1,2) >> $GITHUB_ENV
       - name: Build with mvnw
-        run: ./mvnw clean test -Punit-tests -Ddockstore-core.version=${{ env.LATEST_VERSION }}-SNAPSHOT -B -ntp -U
-      - name: Check what changed
-        run: git diff
+        run: ./mvnw clean install

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.util=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -323,7 +323,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>3.1.12.2</version>
+                    <version>4.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -361,7 +361,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
+                    <version>3.0.0-M3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -476,7 +476,7 @@
                                     <version>3.8.1</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>[11.0.11,12.0)</version>
+                                    <version>[11.0.11,18.0)</version>
                                 </requireJavaVersion>
                                 <banDuplicatePomDependencyVersions />
                                 <bannedDependencies>


### PR DESCRIPTION
CLI version of getting unit tests working in Java 17
Not enforcing Java 17 yet since it runs on the users end
But this stops us from checking in anything that doesn't compile and unit test properly in Java 17 at least

Issue
https://ucsc-cgl.atlassian.net/browse/DOCK-1436
Follows https://github.com/dockstore/dockstore/pull/4492

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
