### PR TITLE
Feature/3437/wes body checksum

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -5,3 +5,7 @@
 # dockstore-client/src/test/java/io/dockstore/client/cli/ApiClientExtendedIT.java
 dockstore-client/src/test/java/io/dockstore/client/cli/ApiClientExtendedIT.java:.*AKIAZHZQVUMXJASEFDT4
 dockstore-client/src/test/java/io/dockstore/client/cli/ApiClientExtendedIT.java:.*orCjq7tE9ejrJRYX2fHFhMW5BZSVWzrfeVIIQO/J
+dockstore-client/src/test/java/io/dockstore/client/cli/ApiClientExtendedIT.java:.*bf918205a9d2ce0cf8a0d1c7cc0eb2ecf42fdefc4ab387eaa1a7958edf26face
+dockstore-client/src/test/java/io/dockstore/client/cli/ApiClientExtendedIT.java:.*dab4ce2c5ff35cc2a99d57b03fb3ed0ece24630d97bfaf1676967b60b5171831
+dockstore-client/src/test/java/io/dockstore/client/cli/ApiClientExtendedIT.java:.*abc30f57ec627a809f6c3b4f738b2863ee8c242f8d4cdd653a37bf47e7bffc0f
+

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 
-Lists of 381 third-party dependencies.
+Lists of 380 third-party dependencies.
      (The Apache Software License, Version 2.0) "Java Concurrency in Practice" book annotations (net.jcip:jcip-annotations:1.0 - http://jcip.net/)
      (Apache License, Version 2.0) akka-actor (com.typesafe.akka:akka-actor_2.12:2.5.31 - https://akka.io/)
      (Apache License, Version 2.0) akka-protobuf (com.typesafe.akka:akka-protobuf_2.12:2.5.31 - https://akka.io/)
@@ -233,7 +233,6 @@ Lists of 381 third-party dependencies.
      (CDDL/GPLv2+CE) JavaBeans Activation Framework (com.sun.activation:javax.activation:1.2.0 - http://java.net/all/javax.activation/)
      (CDDL/GPLv2+CE) JavaBeans Activation Framework API jar (javax.activation:javax.activation-api:1.2.0 - http://java.net/all/javax.activation-api/)
      (Apache License 2.0) (LGPL 2.1) (MPL 1.1) Javassist (org.javassist:javassist:3.28.0-GA - http://www.javassist.org/)
-     (CDDL + GPLv2 with classpath exception) javax.annotation API (javax.annotation:javax.annotation-api:1.3.2 - http://jcp.org/en/jsr/detail?id=250)
      (EPL 2.0) (GPL2 w/ CPE) javax.inject:1 as OSGi bundle (org.glassfish.hk2.external:jakarta.inject:2.6.1 - https://github.com/eclipse-ee4j/glassfish-hk2/external/jakarta.inject)
      (Eclipse Distribution License v. 1.0) (Eclipse Public License v1.0) javax.persistence-api (javax.persistence:javax.persistence-api:2.2 - https://github.com/javaee/jpa-spec)
      (CDDL + GPLv2 with classpath exception) javax.transaction API (javax.transaction:javax.transaction-api:1.3 - http://jta-spec.java.net)

--- a/dockstore-client/generated/src/main/resources/pom.xml
+++ b/dockstore-client/generated/src/main/resources/pom.xml
@@ -247,12 +247,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.3.2</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>ro.fortsoft.pf4j</groupId>
       <artifactId>pf4j</artifactId>
       <version>1.1.1</version>
@@ -323,6 +317,12 @@
       <groupId>uk.co.lucasweb</groupId>
       <artifactId>aws-v4-signer-java</artifactId>
       <version>1.3</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>1.3.5</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -212,12 +212,10 @@
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-exec</artifactId>
         </dependency>
-
         <dependency>
             <groupId>ro.fortsoft.pf4j</groupId>
             <artifactId>pf4j</artifactId>

--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -219,10 +219,6 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>ro.fortsoft.pf4j</groupId>
             <artifactId>pf4j</artifactId>
         </dependency>
@@ -288,6 +284,10 @@
             <groupId>uk.co.lucasweb</groupId>
             <artifactId>aws-v4-signer-java</artifactId>
             <version>1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
     </dependencies>
 
@@ -372,7 +372,6 @@
                                 <ignoredUnusedDeclaredDependency>org.glassfish.jersey.inject:jersey-hk2</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                             <usedDependencies>
-                                <usedDependency>javax.annotation:javax.annotation-api</usedDependency>
                                 <usedDependency>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base</usedDependency>
                                 <usedDependency>io.spray:spray-json_2.12</usedDependency>
                             </usedDependencies>

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -1036,7 +1036,7 @@ public abstract class AbstractEntryClient<T> {
      */
     WorkflowExecutionServiceApi getWorkflowExecutionServiceApi() {
 
-        if (wesRequestData == null) {
+        if (this.getWesRequestData() == null) {
             errorMessage("The WES request data object was not created. This must be populated to generate the client APIs", GENERIC_ERROR);
         }
         
@@ -1052,6 +1052,7 @@ public abstract class AbstractEntryClient<T> {
         // Delete these next two lines when Swagger Codegen is fixed
         ApiClientExtended wesApiClient = new ApiClientExtended(wesRequestData);
         clientWorkflowExecutionServiceApi.setApiClient(wesApiClient);
+        wesApiClient.getHttpClient().register(WesChecksumFilter.class);
 
         wesApiClient.setBasePath(wesRequestData.getUrl());
 

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -1059,6 +1059,7 @@ public abstract class AbstractEntryClient<T> {
         // Add these headers to the http request. Are these needed?
         wesApiClient.addDefaultHeader("Accept", "*/*");
         wesApiClient.addDefaultHeader("Expect", "100-continue");
+        // TODO Might want to override the default User Agent header with a custom one to make tracking WES requests easier.
 
         clientWorkflowExecutionServiceApi.setApiClient(wesApiClient);
         return clientWorkflowExecutionServiceApi;

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
@@ -22,7 +22,6 @@ import javax.ws.rs.core.Response;
 import io.openapi.wes.client.ApiClient;
 import io.openapi.wes.client.ApiException;
 import io.openapi.wes.client.Pair;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.http.HttpStatus;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
@@ -46,6 +45,10 @@ public class ApiClientExtended extends ApiClient {
 
     public ApiClientExtended(WesRequestData wesRequestData) {
         this.wesRequestData = wesRequestData;
+    }
+
+    public WesRequestData getWesRequestData() {
+        return wesRequestData;
     }
 
     /**
@@ -270,13 +273,14 @@ public class ApiClientExtended extends ApiClient {
     }
 
     /**
-     * This will calculate the appropriate AWS signature for a request.
+     * This will set the appropriate variables so the final Authorization header may be calculated in a Jersey hook
+     *
      * @param target The target endpoint
      * @param method The HTTP method (GET, POST, etc ...)
      * @param allHeaders A list of header parameters custom to this request
      * @return A string the should be set under the Authorization header for AWS HTTP requests
      */
-    public String generateAwsSignature(WebTarget target, String method, Map<String, String> allHeaders) {
+    public void setAwsHeaderCalculationData(WebTarget target, String method, Map<String, String> allHeaders) {
         HttpRequest request = new HttpRequest(method, target.getUri());
 
         // Our signature object. We will add all necessary headers to this request that comprise the 'canonical' HTTP request.
@@ -292,18 +296,10 @@ public class ApiClientExtended extends ApiClient {
             authSignature.header(mapEntry.getKey(), mapEntry.getValue());
         }
 
-        // Point the jersey filter to this object so we can calculate the final AWS authorization header if needed
-        WesChecksumFilter.setClientExtended(this);
-
         // Not ideal, but we need to save some of the signature creation objects so we have the necessary information
         // to calculate the Authorization header for requests with a payload. This isn't calculable until we're already
         // making the request with jersey.
         setAwsAuthMetadata(authSignature, request);
-
-        // Set the Authorization header for a bodiless request. This may get overridden by a jersey filter, if this
-        // request as a payload.
-        String contentSha256 = DigestUtils.sha256Hex("");
-        return awsAuthSignature.build(awsHttpRequest, AWS_WES_SERVICE_NAME, contentSha256).getSignature();
     }
 
     /**
@@ -346,16 +342,16 @@ public class ApiClientExtended extends ApiClient {
             invocationBuilder.header(mapEntry.getKey(), mapEntry.getValue());
         }
 
-        // If credentials were passed in, then we want to add an Authorization header, otherwise skip
-        if (this.wesRequestData.hasCredentials()) {
-            // If the request requires AWS auth headers, calculate the signature, otherwise just get the standard bearer token
-            final String authorizationHeader = requiresAwsHeaders
-                ? generateAwsSignature(target, method, mergedHeaderMap) : this.wesRequestData.getBearerToken();
-
-            // Add the Authorization header. This should be the last modification to the InvocationBuilder to ensure the signature remains valid
-            invocationBuilder.header(HttpHeaders.AUTHORIZATION, authorizationHeader);
+        // If this request has credentials and is to an AWS endpoint, we need to set some signature calculation data.
+        // This will allow the jersey hook (WesChecksumFilter.java) to correctly calculate the Authorization header.
+        if (this.wesRequestData.hasCredentials() && requiresAwsHeaders) {
+            setAwsHeaderCalculationData(target, method, mergedHeaderMap);
         }
 
+        // Point the jersey filter to this object so we can calculate the Authorization header if needed
+        WesChecksumFilter.setClientExtended(this);
+
+        // This invocation has no Authorization header set, that is handle in a Jersey hook
         return invocationBuilder;
     }
 

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
@@ -278,7 +278,6 @@ public class ApiClientExtended extends ApiClient {
      * @param target The target endpoint
      * @param method The HTTP method (GET, POST, etc ...)
      * @param allHeaders A list of header parameters custom to this request
-     * @return A string the should be set under the Authorization header for AWS HTTP requests
      */
     public void setAwsHeaderCalculationData(WebTarget target, String method, Map<String, String> allHeaders) {
         HttpRequest request = new HttpRequest(method, target.getUri());
@@ -326,6 +325,8 @@ public class ApiClientExtended extends ApiClient {
     /**
      * Creates an Invocation.Builder that will be used to make a WES request. If the request is to be sent to an AWS endpoint
      * a SigV4 Authorization header needs to be calculated based on the canonical request (https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
+     * The first step to calculating the AWS Authorization header is made here, but the Authorization header isn't set until later (In a Jersey hook)
+     * 
      * @param requiresAwsHeaders Boolean value indicating if this request requires AWS-specific headers
      * @param target The target endpoint
      * @param method The HTTP method (GET, POST, etc ...)

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesChecksumFilter.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesChecksumFilter.java
@@ -65,6 +65,13 @@ public class WesChecksumFilter implements ClientRequestFilter {
         }
     }
 
+    /**
+     * This will calculate the appropriate AWS SigV4 signature for the current request
+     *
+     * @param requestContext The request context
+     * @return A string signature that should be set as the Authorization for this HTTP request
+     * @throws IOException
+     */
     private String generateAwsSignature(ClientRequestContext requestContext) throws IOException {
 
         String contentSha256;

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesChecksumFilter.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesChecksumFilter.java
@@ -1,0 +1,72 @@
+package io.dockstore.client.cli.nested;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+import javax.ws.rs.ext.Providers;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import uk.co.lucasweb.aws.v4.signer.HttpRequest;
+import uk.co.lucasweb.aws.v4.signer.Signer;
+
+@Provider
+@Priority(Priorities.AUTHENTICATION)
+public class WesChecksumFilter implements ClientRequestFilter {
+
+    // This filter is a singleton, so these static variables shouldn't cause any issues, but this is not thread safe.
+    public static Signer.Builder signatureBuilder = null;
+    public static HttpRequest httpRequest = null;
+    public static String serviceName = null;
+
+    /**
+     * Injectable helper to look up appropriate {@link Provider}s
+     * for our body parts.
+     */
+    @Context
+    private Providers providers;
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+
+        // If the request doesn't have an entity (no body content) we don't need to calculate a checksum
+        if (requestContext.getEntity() == null) {
+            return;
+        }
+
+        // Get the message body writer based on the entity type
+        final MessageBodyWriter bodyWriter = providers.getMessageBodyWriter(
+            requestContext.getEntity().getClass(),
+            requestContext.getEntity().getClass(),
+            requestContext.getEntityAnnotations(),
+            requestContext.getMediaType());
+
+        // Write the Entity to a byte stream using the MessageBodyWriter for our entity type
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        bodyWriter.writeTo(requestContext.getEntity(),
+            requestContext.getEntity().getClass(),
+            requestContext.getEntity().getClass(),
+            requestContext.getEntityAnnotations(),
+            requestContext.getMediaType(),
+            requestContext.getHeaders(),
+            buffer);
+
+        // Close the buffer
+        buffer.close();
+
+        // Calculate the sha256 of the content
+        byte[] data = buffer.toByteArray();
+        String contentSha256 = DigestUtils.sha256Hex(data);
+        String AwsAuthHeader = signatureBuilder.build(httpRequest, serviceName, contentSha256).getSignature();
+
+        // Add this as the Authorization header to the request object
+        requestContext.getHeaders().putSingle(HttpHeaders.AUTHORIZATION, AwsAuthHeader);
+    }
+}

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesChecksumFilter.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesChecksumFilter.java
@@ -13,10 +13,7 @@ import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
 import javax.ws.rs.ext.Providers;
 
-import io.dockstore.client.cli.Client;
 import org.apache.commons.codec.digest.DigestUtils;
-
-import static io.dockstore.client.cli.ArgumentUtility.exceptionMessage;
 
 @Provider
 @Priority(Priorities.AUTHENTICATION)

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesChecksumFilter.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesChecksumFilter.java
@@ -39,6 +39,14 @@ public class WesChecksumFilter implements ClientRequestFilter {
         WesChecksumFilter.clientExtended = clientExtended;
     }
 
+    /**
+     * This filter intercepts the jersey request before it is sent and attempts to calculate an AWS SigV4 Authorization header if needed.
+     * If the request does not have a body, or if the static class variable clientExtended is not set, this filter will not do anything. This
+     * Covers scenarios where the request has no payload and/or is not to an AWS endpoint.
+     *
+     * @param requestContext jersey requestContext
+     * @throws IOException
+     */
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {
 
@@ -71,9 +79,9 @@ public class WesChecksumFilter implements ClientRequestFilter {
         // Calculate a sha256 of the content in the buffer
         byte[] content = buffer.toByteArray();
         String contentSha256 = DigestUtils.sha256Hex(content);
-        String AwsAuthHeader = clientExtended.generateAwsContentSignature(contentSha256);
+        String awsAuthHeader = clientExtended.generateAwsContentSignature(contentSha256);
 
         // Add this as the Authorization header to the request object
-        requestContext.getHeaders().putSingle(HttpHeaders.AUTHORIZATION, AwsAuthHeader);
+        requestContext.getHeaders().putSingle(HttpHeaders.AUTHORIZATION, awsAuthHeader);
     }
 }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -1208,6 +1208,8 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
         private boolean help = false;
         @Parameter(names = "--uuid", description = "Allows you to specify a uuid for 3rd party notifications")
         private String uuid;
+        @Parameter(names = "--aws", description = "Indicates this command is to an AWS endpoint")
+        private boolean isAws = false;
     }
 
 }

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/ApiClientExtendedIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/ApiClientExtendedIT.java
@@ -8,14 +8,16 @@ import javax.ws.rs.core.HttpHeaders;
 
 import io.dockstore.client.cli.nested.ApiClientExtended;
 import io.dockstore.client.cli.nested.WesRequestData;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class ApiClientExtendedIT {
 
     // These are old keys that have been deleted.
-    static final String WES_ENDPOINT = "https://eoof9s4bbe.execute-api.us-west-2.amazonaws.com/prod/ga4gh/wes/v1/service-info";
+    static final String WES_ENDPOINT = "https://eoof9s4bbe.execute-api.us-west-2.amazonaws.com/prod/ga4gh/wes/v1";
     static final String OLD_AWS_ACCESS_KEY = "AKIAZHZQVUMXJASEFDT4";
     static final String OLD_AWS_SECRET_KEY = "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";
     static final String AWS_REGION = "us-west-2";
@@ -27,7 +29,7 @@ public class ApiClientExtendedIT {
      */
     @Test
     public void testAwsSigCalculation() {
-        WesRequestData wrd = new WesRequestData(WES_ENDPOINT, OLD_AWS_ACCESS_KEY, OLD_AWS_SECRET_KEY, AWS_REGION);
+        WesRequestData wrd = new WesRequestData(WES_ENDPOINT + "/service-info", OLD_AWS_ACCESS_KEY, OLD_AWS_SECRET_KEY, AWS_REGION);
         ApiClientExtended ace = new ApiClientExtended(wrd);
 
         final WebTarget target = ace.getHttpClient().target(wrd.getUrl());
@@ -41,5 +43,47 @@ public class ApiClientExtendedIT {
         final String newlyCalculatedHeader = ace.generateAwsSignature(target, method, allHeaders);
 
         assertEquals("The calculated header should match the original request that was made", expectedHeader, newlyCalculatedHeader);
+    }
+
+    @Test
+    public void testSameSigForEmptyPayload() {
+        WesRequestData wrd = new WesRequestData(WES_ENDPOINT + "/runs", OLD_AWS_ACCESS_KEY, OLD_AWS_SECRET_KEY, AWS_REGION);
+        ApiClientExtended ace = new ApiClientExtended(wrd);
+
+        final WebTarget target = ace.getHttpClient().target(wrd.getUrl());
+        final String method = "GET";
+        final Map<String, String> allHeaders = new TreeMap<>();
+        allHeaders.put(HttpHeaders.ACCEPT, "*/*");
+        allHeaders.put(HttpHeaders.USER_AGENT, "Swagger-Codegen/1.0.0/java");
+        allHeaders.put("x-amz-date", "20211027T163015Z"); // Don't change this date setting
+
+        final String expectedSignature = ace.generateAwsSignature(target, method, allHeaders); // This needs to be executed so the Jersey filter interceptor can generate the final header.
+        final String fakeBodyChecksum = DigestUtils.sha256Hex("".getBytes());
+        final String newlyCalculatedContentHeader = ace.generateAwsContentSignature(fakeBodyChecksum);
+
+        assertEquals("The calculated header should match the original request that was made", expectedSignature, newlyCalculatedContentHeader);
+    }
+
+    @Test
+    public void testAwsSigCalculationForBody() {
+        WesRequestData wrd = new WesRequestData(WES_ENDPOINT + "/runs", OLD_AWS_ACCESS_KEY, OLD_AWS_SECRET_KEY, AWS_REGION);
+        ApiClientExtended ace = new ApiClientExtended(wrd);
+
+        final WebTarget target = ace.getHttpClient().target(wrd.getUrl());
+        final String method = "POST";
+        final Map<String, String> allHeaders = new TreeMap<>();
+        allHeaders.put(HttpHeaders.ACCEPT, "*/*");
+        allHeaders.put(HttpHeaders.USER_AGENT, "Swagger-Codegen/1.0.0/java");
+        allHeaders.put("x-amz-date", "20211027T163927Z"); // Don't change this date setting
+
+        final String expectedHeader = "AWS4-HMAC-SHA256 Credential=AKIAZHZQVUMXJASEFDT4/20211027/us-west-2/execute-api/aws4_request, SignedHeaders=accept;host;user-agent;x-amz-date, Signature=dab4ce2c5ff35cc2a99d57b03fb3ed0ece24630d97bfaf1676967b60b5171831";
+        final String originalHeader = ace.generateAwsSignature(target, method, allHeaders); // This needs to be executed so the Jersey filter interceptor can generate the final header.
+
+        // The checksum of a multipart body request.
+        final String fakeBodyChecksum = "bf918205a9d2ce0cf8a0d1c7cc0eb2ecf42fdefc4ab387eaa1a7958edf26face";
+        final String newlyCalculatedContentHeader = ace.generateAwsContentSignature(fakeBodyChecksum);
+
+        assertNotEquals("The original header should not match the header after the body checksum has been calculated.", originalHeader, newlyCalculatedContentHeader);
+        assertEquals("The calculated header should match the original request that was made", expectedHeader, newlyCalculatedContentHeader);
     }
 }


### PR DESCRIPTION
Calculates a signature off of the HTTP request's MultiPart body and adds it as the Authorization header for AWS WES requests. https://ucsc-cgl.atlassian.net/browse/SEAB-3437

Although this approach is able to make authenticated requests to the AWS API, it does not meet the end goal of launching a workflow on an AWS WES server due to the current supported WES functionality of AGC. To address this, the payload can instead pass a TRS URL to the desired workflow, rather than inlining the descriptor files directly. This is implemented in a separate PR targeted at this branch: https://github.com/dockstore/dockstore-cli/pull/92