### PR TITLE
Update cron.yml with channel

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -35,6 +35,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.14.0
         with:
             slack-message: 'dockstore-cli/.github/workflows/cron.yml has failed!'
+            channel-id: 'CTWPH9Q03'  # Slack channel id to post message
         env:
             SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 


### PR DESCRIPTION
https://github.com/dockstore/dockstore-cli/runs/4030344589?check_suite_focus=true 
did not seem to show up anywhere, adding a specific channel rather than relying on the token default

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
