### PR TITLE
cron.yml fix notify

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -37,5 +37,5 @@ jobs:
             slack-message: 'dockstore-cli/.github/workflows/cron.yml has failed!'
             channel-id: 'CTWPH9Q03'  # Slack channel id to post message
         env:
-            SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -38,4 +38,5 @@ jobs:
             channel-id: 'CTWPH9Q03'  # Slack channel id to post message
         env:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 


### PR DESCRIPTION
Cron on 2021-11-16 failed to trigger message on Slack
Looks like mismatch between secret and cron.yml

Problematic action is https://github.com/slackapi/slack-github-action#slack-incoming-webhook-route

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
