### PR TITLE
Feature/3663/WesWithJCommander

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
@@ -42,20 +42,20 @@ public class WesCommandParser {
     @Parameters(separators = "=", commandDescription = "Execute WES commands")
     public static class WesMain {
         @Parameter(names = "--wes-url", description = "The URL of the WES server.", required = false)
-        private static String wesUrl = null;
+        private String wesUrl = null;
         @Parameter(names = "--wes-auth",
             description = "The authorization type and value of this wes request. --wes-auth <type> <value>. "
                 + "Type can be 'bearer' or 'aws'. "
                 + "Value can be a token if the type is 'bearer', or an AWS profile if the type is 'aws'",
             variableArity = true,
             required = false)
-        private static List<String> wesAuth = null;
+        private List<String> wesAuth = null;
         @Parameter(names = "--aws-config", description = "A path to an AWS configuration file containing AWS profile credentials.", required = false)
-        private static String awsConfig = null;
+        private String awsConfig = null;
         @Parameter(names = "--aws-region", description = "The AWS region of the WES server.", required = false)
-        private static String awsRegion = null;
+        private String awsRegion = null;
         @Parameter(names = "--help", description = "Prints help for launch command", help = true)
-        private static boolean help = false;
+        private boolean help = false;
 
         /**
          * Returns the WES authorization type (bearer or aws). If no auth type was provided, return null

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
@@ -56,14 +56,6 @@ public class WesCommandParser {
         private boolean help = false;
 
         /**
-         * Returns the URL for the WES request, if provided on the command line.
-         * @return
-         */
-        public String getWesUrl() {
-            return wesUrl;
-        }
-
-        /**
          * Returns the WES authorization type (bearer or aws). If no auth type was provided, return null
          * @return
          */
@@ -71,7 +63,7 @@ public class WesCommandParser {
             if (wesAuth != null && !wesAuth.isEmpty()) {
                 return wesAuth.get(0);
             }
-                return null;
+            return null;
         }
 
         /**
@@ -83,6 +75,10 @@ public class WesCommandParser {
                 return wesAuth.get(1);
             }
             return null;
+        }
+
+        public String getWesUrl() {
+            return wesUrl;
         }
 
         public String getAwsConfig() {
@@ -98,7 +94,7 @@ public class WesCommandParser {
         }
     }
 
-    @Parameters(separators = "=", commandDescription = "Launch a workflow using WES.")
+    @Parameters(separators = "=", commandDescription = "Launch a workflow using WES")
     public static class CommandLaunch {
         @Parameter(names = "--entry", description = "Complete workflow path in Dockstore (ex. NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq:master)", required = true)
         private String entry;

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
@@ -1,0 +1,100 @@
+package io.dockstore.client.cli.nested;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.beust.jcommander.SubParameter;
+import org.apache.commons.lang3.EnumUtils;
+
+import static io.dockstore.client.cli.ArgumentUtility.out;
+
+public class WesCommandParser {
+
+    public WesMain wesMain;
+    public CommandLaunch commandLaunch;
+
+    public WesCommandParser() {
+        this.wesMain = new WesMain();
+        this.commandLaunch = new CommandLaunch();
+    }
+
+    public JCommander buildWesCommandParser() {
+
+        // Build JCommander
+        return JCommander.newBuilder()
+            .addObject(this.wesMain)
+            .addCommand("launch", this.commandLaunch)
+            .build();
+    }
+
+    @Parameters(separators = "=", commandDescription = "Execute WES commands")
+    public static class WesMain {
+        @Parameter(names = "--wes-url", description = "The URL of the WES server.", required = false)
+        private String wesUrl = null;
+        @Parameter(names = "--wes-auth",
+            description = "The authorization type and value of this wes request. --wes-auth <type> <value>. "
+                + "Type can be 'bearer' or 'aws'. "
+                + "Value can be a token if the type is 'bearer', or an AWS profile if the type is 'aws'",
+            variableArity = true,
+            required = false)
+        private List<String> wesAuth = null;
+        @Parameter(names = "--aws-config", description = "A path to an AWS configuration file containing AWS profile credentials.", required = false)
+        private String awsConfig = null;
+        @Parameter(names = "--aws-region", description = "The AWS region of the WES server.", required = true)
+        private String awsRegion = null;
+        @Parameter(names = "--help", description = "Prints help for launch command", help = true)
+        private boolean help = false;
+
+        /**
+         * Returns the URL for the WES request, if provided on the command line.
+         * @return
+         */
+        public String getWesUrl() {
+            return wesUrl;
+        }
+
+        /**
+         * Returns the WES authorization type (bearer or aws)
+         * @return
+         */
+        public String getWesAuthType() {
+            if (wesAuth != null && !wesAuth.isEmpty()) {
+                return wesAuth.get(0);
+            }
+                return null;
+        }
+
+        /**
+         * Returns the WES authorization value (token or AWS profile).
+         * @return
+         */
+        public String getWesAuthValue() {
+            if (wesAuth != null && wesAuth.size() > 1) {
+                return wesAuth.get(1);
+            }
+            return null;
+        }
+    }
+
+    @Parameters(separators = "=", commandDescription = "Launch an entry locally or remotely.")
+    public static class CommandLaunch {
+        @Parameter(names = "--entry", description = "Complete workflow path in Dockstore (ex. NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq:master)")
+        private String entry;
+        @Parameter(names = "--json", description = "Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs")
+        private String json;
+        @Parameter(names = "--yaml", description = "Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs")
+        private String yaml;
+        @Parameter(names = "--help", description = "Prints help for launch command", help = true)
+        private boolean help = false;
+        @Parameter(names = "--uuid", description = "Allows you to specify a uuid for 3rd party notifications")
+        private String uuid;
+        @Parameter(names = "--aws", description = "Indicates this command is to an AWS endpoint")
+        private boolean isAws = false;
+    }
+
+}

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
@@ -1,34 +1,39 @@
 package io.dockstore.client.cli.nested;
 
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-import com.beust.jcommander.SubParameter;
-import org.apache.commons.lang3.EnumUtils;
-
-import static io.dockstore.client.cli.ArgumentUtility.out;
 
 public class WesCommandParser {
 
     public WesMain wesMain;
     public CommandLaunch commandLaunch;
+    public CommandCancel commandCancel;
+    public CommandStatus commandStatus;
+    public CommandServiceInfo commandServiceInfo;
+    public JCommander jCommander;
 
     public WesCommandParser() {
         this.wesMain = new WesMain();
         this.commandLaunch = new CommandLaunch();
+        this.commandCancel = new CommandCancel();
+        this.commandStatus = new CommandStatus();
+        this.commandServiceInfo = new CommandServiceInfo();
+
+        this.jCommander = buildWesCommandParser();
     }
 
-    public JCommander buildWesCommandParser() {
+    private JCommander buildWesCommandParser() {
 
         // Build JCommander
         return JCommander.newBuilder()
             .addObject(this.wesMain)
             .addCommand("launch", this.commandLaunch)
+            .addCommand("cancel", this.commandCancel)
+            .addCommand("status", this.commandStatus)
+            .addCommand("service-info", this.commandServiceInfo)
             .build();
     }
 
@@ -45,7 +50,7 @@ public class WesCommandParser {
         private List<String> wesAuth = null;
         @Parameter(names = "--aws-config", description = "A path to an AWS configuration file containing AWS profile credentials.", required = false)
         private String awsConfig = null;
-        @Parameter(names = "--aws-region", description = "The AWS region of the WES server.", required = true)
+        @Parameter(names = "--aws-region", description = "The AWS region of the WES server.", required = false)
         private String awsRegion = null;
         @Parameter(names = "--help", description = "Prints help for launch command", help = true)
         private boolean help = false;
@@ -59,7 +64,7 @@ public class WesCommandParser {
         }
 
         /**
-         * Returns the WES authorization type (bearer or aws)
+         * Returns the WES authorization type (bearer or aws). If no auth type was provided, return null
          * @return
          */
         public String getWesAuthType() {
@@ -70,7 +75,7 @@ public class WesCommandParser {
         }
 
         /**
-         * Returns the WES authorization value (token or AWS profile).
+         * Returns the WES authorization value (token or AWS profile). If no auth value was provided, return null.
          * @return
          */
         public String getWesAuthValue() {
@@ -79,11 +84,23 @@ public class WesCommandParser {
             }
             return null;
         }
+
+        public String getAwsConfig() {
+            return awsConfig;
+        }
+
+        public String getAwsRegion() {
+            return awsRegion;
+        }
+
+        public boolean isHelp() {
+            return help;
+        }
     }
 
-    @Parameters(separators = "=", commandDescription = "Launch an entry locally or remotely.")
+    @Parameters(separators = "=", commandDescription = "Launch a workflow using WES.")
     public static class CommandLaunch {
-        @Parameter(names = "--entry", description = "Complete workflow path in Dockstore (ex. NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq:master)")
+        @Parameter(names = "--entry", description = "Complete workflow path in Dockstore (ex. NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq:master)", required = true)
         private String entry;
         @Parameter(names = "--json", description = "Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs")
         private String json;
@@ -93,8 +110,74 @@ public class WesCommandParser {
         private boolean help = false;
         @Parameter(names = "--uuid", description = "Allows you to specify a uuid for 3rd party notifications")
         private String uuid;
-        @Parameter(names = "--aws", description = "Indicates this command is to an AWS endpoint")
-        private boolean isAws = false;
+
+        public String getEntry() {
+            return entry;
+        }
+
+        public String getJson() {
+            return json;
+        }
+
+        public String getYaml() {
+            return yaml;
+        }
+
+        public boolean isHelp() {
+            return help;
+        }
+
+        public String getUuid() {
+            return uuid;
+        }
+    }
+
+    @Parameters(separators = "=", commandDescription = "Cancel a remote WES entry")
+    public static class CommandCancel {
+        @Parameter(names = "--help", description = "Prints help for the cancel command", help = true)
+        private boolean help = false;
+        @Parameter(names = "--id", description = "The ID of the workflow to cancel", required = true)
+        private String id;
+
+        public boolean isHelp() {
+            return help;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+
+    @Parameters(separators = "=", commandDescription = "Retrieve the status of a workflow")
+    public static class CommandStatus {
+        @Parameter(names = "--help", description = "Prints help for the cancel command", help = true)
+        private boolean help = false;
+        @Parameter(names = "--id", description = "The ID of the workflow to cancel", required = true)
+        private String id;
+        @Parameter(names = "--verbose", description = "Flag indicating to print verbose logs", required = false)
+        private boolean verbose = false;
+
+        public boolean isHelp() {
+            return help;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public boolean isVerbose() {
+            return verbose;
+        }
+    }
+
+    @Parameters(separators = "=", commandDescription = "Retrieve info about a WES server")
+    public static class CommandServiceInfo {
+        @Parameter(names = "--help", description = "Prints help for the cancel command", help = true)
+        private boolean help = false;
+
+        public boolean isHelp() {
+            return help;
+        }
     }
 
 }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
@@ -2,8 +2,10 @@ package io.dockstore.client.cli.nested;
 
 import java.util.List;
 
+import com.beust.jcommander.IParameterValidator;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 
 public class WesCommandParser {
@@ -40,20 +42,20 @@ public class WesCommandParser {
     @Parameters(separators = "=", commandDescription = "Execute WES commands")
     public static class WesMain {
         @Parameter(names = "--wes-url", description = "The URL of the WES server.", required = false)
-        private String wesUrl = null;
+        private static String wesUrl = null;
         @Parameter(names = "--wes-auth",
             description = "The authorization type and value of this wes request. --wes-auth <type> <value>. "
                 + "Type can be 'bearer' or 'aws'. "
                 + "Value can be a token if the type is 'bearer', or an AWS profile if the type is 'aws'",
             variableArity = true,
             required = false)
-        private List<String> wesAuth = null;
+        private static List<String> wesAuth = null;
         @Parameter(names = "--aws-config", description = "A path to an AWS configuration file containing AWS profile credentials.", required = false)
-        private String awsConfig = null;
+        private static String awsConfig = null;
         @Parameter(names = "--aws-region", description = "The AWS region of the WES server.", required = false)
-        private String awsRegion = null;
+        private static String awsRegion = null;
         @Parameter(names = "--help", description = "Prints help for launch command", help = true)
-        private boolean help = false;
+        private static boolean help = false;
 
         /**
          * Returns the WES authorization type (bearer or aws). If no auth type was provided, return null

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
@@ -2,10 +2,8 @@ package io.dockstore.client.cli.nested;
 
 import java.util.List;
 
-import com.beust.jcommander.IParameterValidator;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
-import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 
 public class WesCommandParser {

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
@@ -95,15 +95,13 @@ public class WesCommandParser {
     }
 
     @Parameters(separators = "=", commandDescription = "Launch a workflow using WES")
-    public static class CommandLaunch {
+    public static class CommandLaunch extends WesMain {
         @Parameter(names = "--entry", description = "Complete workflow path in Dockstore (ex. NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq:master)", required = true)
         private String entry;
         @Parameter(names = "--json", description = "Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs")
         private String json;
         @Parameter(names = "--yaml", description = "Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs")
         private String yaml;
-        @Parameter(names = "--help", description = "Prints help for launch command", help = true)
-        private boolean help = false;
         @Parameter(names = "--uuid", description = "Allows you to specify a uuid for 3rd party notifications")
         private String uuid;
 
@@ -119,25 +117,15 @@ public class WesCommandParser {
             return yaml;
         }
 
-        public boolean isHelp() {
-            return help;
-        }
-
         public String getUuid() {
             return uuid;
         }
     }
 
     @Parameters(separators = "=", commandDescription = "Cancel a remote WES entry")
-    public static class CommandCancel {
-        @Parameter(names = "--help", description = "Prints help for the cancel command", help = true)
-        private boolean help = false;
+    public static class CommandCancel extends WesMain {
         @Parameter(names = "--id", description = "The ID of the workflow to cancel", required = true)
         private String id;
-
-        public boolean isHelp() {
-            return help;
-        }
 
         public String getId() {
             return id;
@@ -145,17 +133,11 @@ public class WesCommandParser {
     }
 
     @Parameters(separators = "=", commandDescription = "Retrieve the status of a workflow")
-    public static class CommandStatus {
-        @Parameter(names = "--help", description = "Prints help for the cancel command", help = true)
-        private boolean help = false;
+    public static class CommandStatus extends WesMain {
         @Parameter(names = "--id", description = "The ID of the workflow to cancel", required = true)
         private String id;
         @Parameter(names = "--verbose", description = "Flag indicating to print verbose logs", required = false)
         private boolean verbose = false;
-
-        public boolean isHelp() {
-            return help;
-        }
 
         public String getId() {
             return id;
@@ -167,13 +149,7 @@ public class WesCommandParser {
     }
 
     @Parameters(separators = "=", commandDescription = "Retrieve info about a WES server")
-    public static class CommandServiceInfo {
-        @Parameter(names = "--help", description = "Prints help for the cancel command", help = true)
-        private boolean help = false;
-
-        public boolean isHelp() {
-            return help;
-        }
+    public static class CommandServiceInfo extends WesMain {
     }
 
 }

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
@@ -1,19 +1,16 @@
 package io.dockstore.client.cli;
 
 import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterException;
 import io.dockstore.client.cli.nested.WesCommandParser;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class WesCommandParserTest {
-
-    @Rule
-    public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
 
     @Test
     public void testWesMainHelp() {
@@ -34,9 +31,7 @@ public class WesCommandParserTest {
         final String wesUrl = "my.wes.url.com/ga4gh/v1/";
         final String[] args = {
             "--wes-url",
-            wesUrl,
-            "--aws-region",
-            "space-mars-2"
+            wesUrl
         };
 
         WesCommandParser wesCommandParser = new WesCommandParser();
@@ -65,6 +60,7 @@ public class WesCommandParserTest {
         parser.parse(args);
 
         assertNull("Parsed command should be null", parser.getParsedCommand());
+        assertEquals("The parsed region should be 'space-mars-2'", "space-mars-2", wesCommandParser.wesMain.getAwsRegion());
         assertEquals("The parsed auth type should be 'aws'", wesAuthType, wesCommandParser.wesMain.getWesAuthType());
         assertEquals("The parsed auth value should be 'my-profile'", wesAuthValue, wesCommandParser.wesMain.getWesAuthValue());
     }
@@ -85,13 +81,10 @@ public class WesCommandParserTest {
 
         assertNull("Parsed command should be null", parser.getParsedCommand());
         assertEquals("The parsed auth type should be 'aws'", wesAuthType, wesCommandParser.wesMain.getWesAuthType());
-        assertEquals("The parsed auth value should be null", null, wesCommandParser.wesMain.getWesAuthValue());
+        assertNull("The parsed auth value should be null", wesCommandParser.wesMain.getWesAuthValue());
     }
 
     @Test
-    /**
-     * Similar to testWesMainAuthPartial2, but just double checks that 'aws' and 'bearer' types are both parsed correctly.
-     */
     public void testWesMainAuthPartial2() {
         final String wesAuthType = "bearer";
         final String[] args = {
@@ -184,6 +177,28 @@ public class WesCommandParserTest {
     }
 
     @Test
+    public void testCommandLaunchNoEntry() {
+        final String[] args = {
+            "--wes-auth",
+            "bearer",
+            "123456",
+            "launch",
+            "--yaml",
+            "path/to/yaml.yaml"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+
+        try {
+            parser.parse(args);
+            fail("The parser should throw an exception for missing '--entry' parameter");
+        } catch (ParameterException e) {
+            assertTrue(true);
+        }
+    }
+
+    @Test
     public void testCommandCancel() {
         final String[] args = {
             "--wes-auth",
@@ -200,5 +215,133 @@ public class WesCommandParserTest {
 
         assertEquals("Parsed command should be 'cancel'", "cancel", parser.getParsedCommand());
         assertEquals("The parsed entry should be '123456'", "123456", wesCommandParser.commandCancel.getId());
+    }
+
+    @Test
+    public void testCommandCancelNoID() {
+        final String[] args = {
+            "--wes-auth",
+            "bearer",
+            "123456",
+            "cancel"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        try {
+            parser.parse(args);
+            fail("The parser should throw an exception for missing '--id' parameter");
+        } catch (ParameterException e) {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testCommandCancelHelp() {
+        final String[] args = {
+            "cancel",
+            "--help"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        parser.parse(args);
+        assertTrue("Help should be set", wesCommandParser.commandCancel.isHelp());
+    }
+
+    @Test
+    public void testCommandStatus1() {
+        final String[] args = {
+            "--wes-auth",
+            "bearer",
+            "123456",
+            "status",
+            "--id",
+            "123456"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        parser.parse(args);
+
+        assertEquals("Parsed command should be 'status'", "status", parser.getParsedCommand());
+        assertEquals("The parsed entry should be '123456'", "123456", wesCommandParser.commandStatus.getId());
+    }
+
+    @Test
+    public void testCommandStatus2() {
+        final String[] args = {
+            "--wes-auth",
+            "bearer",
+            "123456",
+            "status",
+            "--id",
+            "123456",
+            "--verbose"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        parser.parse(args);
+
+        assertEquals("Parsed command should be 'status'", "status", parser.getParsedCommand());
+        assertEquals("The parsed entry should be '123456'", "123456", wesCommandParser.commandStatus.getId());
+        assertTrue("verbose flag should be set", wesCommandParser.commandStatus.isVerbose());
+    }
+
+    @Test
+    public void testCommandStatusNoID() {
+        final String[] args = {
+            "--wes-auth",
+            "bearer",
+            "123456",
+            "status"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        try {
+            parser.parse(args);
+            fail("The parser should throw an exception for missing '--id' parameter");
+        } catch (ParameterException e) {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testCommandStatusHelp() {
+        final String[] args = {
+            "status",
+            "--help"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        parser.parse(args);
+        assertTrue("Help should be set", wesCommandParser.commandStatus.isHelp());
+    }
+
+    @Test
+    public void testCommandServiceInfo() {
+        final String[] args = {
+            "service-info"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        parser.parse(args);
+    }
+
+    @Test
+    public void testCommandServiceInfoHelp() {
+        final String[] args = {
+            "service-info",
+            "--help"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        parser.parse(args);
+        assertTrue("Help should be set", wesCommandParser.commandServiceInfo.isHelp());
     }
 }

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
@@ -1,0 +1,76 @@
+package io.dockstore.client.cli;
+
+import com.beust.jcommander.JCommander;
+import io.dockstore.client.cli.nested.WesCommandParser;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class WesCommandParserTest {
+
+    @Test
+    public void testWesMainHelp() {
+        final String[] args = {
+            "--help"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.buildWesCommandParser();
+        parser.parse(args);
+        //assertTrue("Should have help value set to true.", wesCommandParser.wesMain.help);
+    }
+
+    @Test
+    public void testWesMainUrl() {
+        final String wesUrl = "my.wes.url.com/ga4gh/v1/";
+        final String[] args = {
+            "--wes-url",
+            wesUrl,
+            "--aws-region",
+            "space-mars-2"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.buildWesCommandParser();
+        parser.parse(args);
+        //assertEquals("The parsed URL should match the URL passed in", wesUrl, wesCommandParser.wesMain.wesUrl);
+    }
+
+    @Test
+    public void testWesMainAuth() {
+        final String wesAuthType = "aws";
+        final String wesAuthValue = "my-profile";
+        final String[] args = {
+            "--aws-region",
+            "space-mars-2",
+            "--wes-auth",
+            wesAuthType,
+            wesAuthValue,
+            "banana"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.buildWesCommandParser();
+        parser.parse(args);
+        assertEquals("The parsed auth type should be 'aws'", wesAuthType, wesCommandParser.wesMain.getWesAuthType());
+        assertEquals("The parsed auth value should be 'my-profile'", wesAuthValue, wesCommandParser.wesMain.getWesAuthValue());
+    }
+
+    @Test
+    public void testWesMainAuthPartial() {
+        final String wesAuthType = "aws";
+        final String[] args = {
+            "--aws-region",
+            "space-mars-2",
+            "--wes-auth",
+            wesAuthType
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.buildWesCommandParser();
+        parser.parse(args);
+        assertEquals("The parsed auth type should be 'aws'", wesAuthType, wesCommandParser.wesMain.getWesAuthType());
+        assertEquals("The parsed auth value should be null", null, wesCommandParser.wesMain.getWesAuthValue());
+    }
+}

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
@@ -2,12 +2,18 @@ package io.dockstore.client.cli;
 
 import com.beust.jcommander.JCommander;
 import io.dockstore.client.cli.nested.WesCommandParser;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class WesCommandParserTest {
+
+    @Rule
+    public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
 
     @Test
     public void testWesMainHelp() {
@@ -16,9 +22,11 @@ public class WesCommandParserTest {
         };
 
         WesCommandParser wesCommandParser = new WesCommandParser();
-        JCommander parser = wesCommandParser.buildWesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
         parser.parse(args);
-        //assertTrue("Should have help value set to true.", wesCommandParser.wesMain.help);
+
+        assertNull("Parsed command should be null", parser.getParsedCommand());
+        assertTrue("Should have help value set to true.", wesCommandParser.wesMain.isHelp());
     }
 
     @Test
@@ -32,9 +40,11 @@ public class WesCommandParserTest {
         };
 
         WesCommandParser wesCommandParser = new WesCommandParser();
-        JCommander parser = wesCommandParser.buildWesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
         parser.parse(args);
-        //assertEquals("The parsed URL should match the URL passed in", wesUrl, wesCommandParser.wesMain.wesUrl);
+
+        assertNull("Parsed command should be null", parser.getParsedCommand());
+        assertEquals("The parsed URL should match the URL passed in", wesUrl, wesCommandParser.wesMain.getWesUrl());
     }
 
     @Test
@@ -51,8 +61,10 @@ public class WesCommandParserTest {
         };
 
         WesCommandParser wesCommandParser = new WesCommandParser();
-        JCommander parser = wesCommandParser.buildWesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
         parser.parse(args);
+
+        assertNull("Parsed command should be null", parser.getParsedCommand());
         assertEquals("The parsed auth type should be 'aws'", wesAuthType, wesCommandParser.wesMain.getWesAuthType());
         assertEquals("The parsed auth value should be 'my-profile'", wesAuthValue, wesCommandParser.wesMain.getWesAuthValue());
     }
@@ -68,9 +80,125 @@ public class WesCommandParserTest {
         };
 
         WesCommandParser wesCommandParser = new WesCommandParser();
-        JCommander parser = wesCommandParser.buildWesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
         parser.parse(args);
+
+        assertNull("Parsed command should be null", parser.getParsedCommand());
         assertEquals("The parsed auth type should be 'aws'", wesAuthType, wesCommandParser.wesMain.getWesAuthType());
         assertEquals("The parsed auth value should be null", null, wesCommandParser.wesMain.getWesAuthValue());
+    }
+
+    @Test
+    /**
+     * Similar to testWesMainAuthPartial2, but just double checks that 'aws' and 'bearer' types are both parsed correctly.
+     */
+    public void testWesMainAuthPartial2() {
+        final String wesAuthType = "bearer";
+        final String[] args = {
+            "--wes-auth",
+            wesAuthType
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        parser.parse(args);
+
+        assertNull("Parsed command should be null", parser.getParsedCommand());
+        assertEquals("The parsed auth type should be 'bearer'", wesAuthType, wesCommandParser.wesMain.getWesAuthType());
+        assertNull("The parsed auth value should be null", wesCommandParser.wesMain.getWesAuthValue());
+    }
+
+    @Test
+    public void testWesMainAuthPartial3() {
+        final String[] args = {}; // make sure we don't crash on no auth provided
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        parser.parse(args);
+
+        assertNull("Parsed command should be null", parser.getParsedCommand());
+        assertNull("The parsed auth type should be 'null'", wesCommandParser.wesMain.getWesAuthType());
+        assertNull("The parsed auth value should be null", wesCommandParser.wesMain.getWesAuthValue());
+    }
+
+    @Test
+    public void testCommandLaunchHelp() {
+        final String[] args = {
+            "--wes-auth",
+            "bearer",
+            "123456",
+            "launch",
+            "--help"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        parser.parse(args);
+
+        assertEquals("Parsed command should be 'launch'", "launch", parser.getParsedCommand());
+        assertTrue("Should be a help command", wesCommandParser.commandLaunch.isHelp());
+    }
+
+    @Test
+    public void testCommandLaunch1() {
+        final String[] args = {
+            "--wes-auth",
+            "bearer",
+            "123456",
+            "launch",
+            "--entry",
+            "my/fake/entry",
+            "--json",
+            "path/to/json.json"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        parser.parse(args);
+
+        assertEquals("Parsed command should be 'launch'", "launch", parser.getParsedCommand());
+        assertEquals("The parsed entry should be 'my/fake/entry'", "my/fake/entry", wesCommandParser.commandLaunch.getEntry());
+        assertEquals("The parsed entry should be 'path/to/json.json'", "path/to/json.json", wesCommandParser.commandLaunch.getJson());
+    }
+
+    @Test
+    public void testCommandLaunch2() {
+        final String[] args = {
+            "--wes-auth",
+            "bearer",
+            "123456",
+            "launch",
+            "--entry",
+            "my/fake/entry",
+            "--yaml",
+            "path/to/yaml.yaml"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        parser.parse(args);
+
+        assertEquals("Parsed command should be 'launch'", "launch", parser.getParsedCommand());
+        assertEquals("The parsed entry should be 'my/fake/entry'", "my/fake/entry", wesCommandParser.commandLaunch.getEntry());
+        assertEquals("The parsed entry should be 'path/to/yaml.yaml'", "path/to/yaml.yaml", wesCommandParser.commandLaunch.getYaml());
+    }
+
+    @Test
+    public void testCommandCancel() {
+        final String[] args = {
+            "--wes-auth",
+            "bearer",
+            "123456",
+            "cancel",
+            "--id",
+            "123456"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        parser.parse(args);
+
+        assertEquals("Parsed command should be 'cancel'", "cancel", parser.getParsedCommand());
+        assertEquals("The parsed entry should be '123456'", "123456", wesCommandParser.commandCancel.getId());
     }
 }

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
@@ -180,6 +180,8 @@ public class WesCommandParserTest {
     public void testCommandLaunch3() {
         final String[] args = {
             "launch",
+            "--wes-url",
+            "banana",
             "--wes-auth",
             "bearer",
             "123456",
@@ -194,6 +196,7 @@ public class WesCommandParserTest {
         parser.parse(args);
 
         assertEquals("Parsed command should be 'launch'", "launch", parser.getParsedCommand());
+        assertEquals("The parsed URL should be 'banana'", "banana", wesCommandParser.wesMain.getWesUrl());
         assertEquals("The parsed entry should be 'my/fake/entry'", "my/fake/entry", wesCommandParser.commandLaunch.getEntry());
         assertEquals("The parsed entry should be 'path/to/yaml.yaml'", "path/to/yaml.yaml", wesCommandParser.commandLaunch.getYaml());
     }

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
@@ -177,6 +177,28 @@ public class WesCommandParserTest {
     }
 
     @Test
+    public void testCommandLaunch3() {
+        final String[] args = {
+            "launch",
+            "--wes-auth",
+            "bearer",
+            "123456",
+            "--entry",
+            "my/fake/entry",
+            "--yaml",
+            "path/to/yaml.yaml"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        parser.parse(args);
+
+        assertEquals("Parsed command should be 'launch'", "launch", parser.getParsedCommand());
+        assertEquals("The parsed entry should be 'my/fake/entry'", "my/fake/entry", wesCommandParser.commandLaunch.getEntry());
+        assertEquals("The parsed entry should be 'path/to/yaml.yaml'", "path/to/yaml.yaml", wesCommandParser.commandLaunch.getYaml());
+    }
+
+    @Test
     public void testCommandLaunchNoEntry() {
         final String[] args = {
             "--wes-auth",

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
@@ -196,7 +196,7 @@ public class WesCommandParserTest {
         parser.parse(args);
 
         assertEquals("Parsed command should be 'launch'", "launch", parser.getParsedCommand());
-        assertEquals("The parsed URL should be 'banana'", "banana", wesCommandParser.wesMain.getWesUrl());
+        assertEquals("The parsed URL should be 'banana'", "banana", wesCommandParser.commandLaunch.getWesUrl());
         assertEquals("The parsed entry should be 'my/fake/entry'", "my/fake/entry", wesCommandParser.commandLaunch.getEntry());
         assertEquals("The parsed entry should be 'path/to/yaml.yaml'", "path/to/yaml.yaml", wesCommandParser.commandLaunch.getYaml());
     }


### PR DESCRIPTION
Ticket: https://ucsc-cgl.atlassian.net/browse/SEAB-3663

This PR is the first half of another ticket, https://ucsc-cgl.atlassian.net/browse/DOCK-1985. In this PR, we add the framework for the Dockstore CLI to use jCommander for WES calls, rather than manual parsing. The actual use of this framework comes into play in the partner PR: https://github.com/dockstore/dockstore-cli/pull/99.

- [X] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
