### PR TITLE
Feature/3477/aws temporary credentials

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -1252,8 +1252,7 @@ public abstract class AbstractEntryClient<T> {
 
                 // Build and return the request data
                 return new WesRequestData(wesEndpointUrl,
-                    credentialsProvider.getCredentials().getAWSAccessKeyId(),
-                    credentialsProvider.getCredentials().getAWSSecretKey(),
+                    credentialsProvider.getCredentials(),
                     regionProvider.getRegion());
 
             } catch (IllegalArgumentException | SdkClientException e) {

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
@@ -37,6 +37,7 @@ public class ApiClientExtended extends ApiClient {
     static final String TIME_ZONE = "UTC";
     static final String DATA_FORMAT = "yyyyMMdd'T'HHmmss'Z'";
     static final String AWS_DATE_HEADER = "x-amz-date";
+    static final String AWS_SESSION_TOKEN_HEADER = "X-Amz-Security-Token";
     static final String AWS_WES_SERVICE_NAME = "execute-api";
 
     static final String WORKFLOW_PARAMS = "workflow_params";
@@ -184,7 +185,7 @@ public class ApiClientExtended extends ApiClient {
             }
         }
 
-        Invocation.Builder invocationBuilder = createInvocation(this.wesRequestData.requiresAwsHeaders(), target, method, headerParams);
+        Invocation.Builder invocationBuilder = createInvocation(target, method, headerParams);
 
         Entity<?> entity = serialize(body, formParams, contentType);
 
@@ -253,7 +254,7 @@ public class ApiClientExtended extends ApiClient {
      * @param headerParams The header parameters passed to the original invokeAPI function
      * @return A merged map of multiple headers.
      */
-    private Map<String, String> mergeHeaders(boolean requiresAwsHeaders, Map<String, String> headerParams) {
+    private Map<String, String> mergeHeaders(boolean requiresAwsHeaders, boolean requiresAwsSessionHeader, Map<String, String> headerParams) {
         // We need the map to be sorted, as AWS requires header orders to be alphabetical
         Map<String, String> mergedHeaderMap = new TreeMap<>();
 
@@ -267,6 +268,11 @@ public class ApiClientExtended extends ApiClient {
             DateFormat dateFormat = new SimpleDateFormat(DATA_FORMAT);
             dateFormat.setTimeZone(TimeZone.getTimeZone(TIME_ZONE));
             mergedHeaderMap.put(AWS_DATE_HEADER, dateFormat.format(new Date()));
+
+            // Add the session token to the header list if we are validating using temporary AWS session credentials
+            if (requiresAwsSessionHeader) {
+                mergedHeaderMap.put(AWS_SESSION_TOKEN_HEADER, this.wesRequestData.getAwsSessionToken());
+            }
 
             // Don't want to calculate our Authorization header off of another Authorization that will subsequently get overridden
             mergedHeaderMap.remove(HttpHeaders.AUTHORIZATION);
@@ -292,7 +298,6 @@ public class ApiClientExtended extends ApiClient {
         // Our signature object. We will add all necessary headers to this request that comprise the 'canonical' HTTP request.
         // This will then be signed alongside a hash of the body content (if there is a body).
         Signer.Builder authSignature = Signer.builder()
-            // TODO this currently only supports permanent AWS credentials
             .awsCredentials(new AwsCredentials(this.wesRequestData.getAwsAccessKey(), this.wesRequestData.getAwsSecretKey()))
             .region(this.wesRequestData.getAwsRegion())
             .header(HttpHeaders.HOST, target.getUri().getHost()); // Have to manually set the Host header as it's required when signing
@@ -334,18 +339,21 @@ public class ApiClientExtended extends ApiClient {
      * a SigV4 Authorization header needs to be calculated based on the canonical request (https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
      * The first step to calculating the AWS Authorization header is made here, but the Authorization header isn't set until later (In a Jersey hook)
      * 
-     * @param requiresAwsHeaders Boolean value indicating if this request requires AWS-specific headers
      * @param target The target endpoint
      * @param method The HTTP method (GET, POST, etc ...)
      * @param headerParams A list of header parameters custom to this request
      * @return An Invocation.Builder that can be used to make an HTTP request
      */
-    private Invocation.Builder createInvocation(boolean requiresAwsHeaders, WebTarget target, String method, Map<String, String> headerParams) {
+    private Invocation.Builder createInvocation(WebTarget target, String method, Map<String, String> headerParams) {
 
         Invocation.Builder invocationBuilder = target.request();
 
+        // boolean values indicating if this request requires AWS-specific headers, and if the request is using temporary AWS credentials
+        final boolean requiresAwsHeaders = this.wesRequestData.usesAwsCredentials();
+        final boolean requiresAwsSessionHeader = this.wesRequestData.requiresAwsSessionHeaders();
+
         // Merge all our different headers into a single object for easier handling then add them to the invocation
-        final Map<String, String> mergedHeaderMap = mergeHeaders(requiresAwsHeaders, headerParams);
+        final Map<String, String> mergedHeaderMap = mergeHeaders(requiresAwsHeaders, requiresAwsSessionHeader, headerParams);
         for (Map.Entry<String, String> mapEntry : mergedHeaderMap.entrySet()) {
             invocationBuilder.header(mapEntry.getKey(), mapEntry.getValue());
         }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
@@ -352,7 +352,7 @@ public class ApiClientExtended extends ApiClient {
 
         // boolean values indicating if this request requires AWS-specific headers, and if the request is using temporary AWS credentials
         final boolean requiresAwsHeaders = this.wesRequestData.usesAwsCredentials();
-        final boolean requiresAwsSessionHeader = this.wesRequestData.requiresAwsSessionHeaders();
+        final boolean requiresAwsSessionHeader = this.wesRequestData.requiresAwsSessionHeader();
 
         // Merge all our different headers into a single object for easier handling then add them to the invocation
         final Map<String, String> mergedHeaderMap = mergeHeaders(requiresAwsHeaders, requiresAwsSessionHeader, headerParams);

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
@@ -251,6 +251,8 @@ public class ApiClientExtended extends ApiClient {
      *  2. The defaultHeaderMap that is set when the Client is created
      *  3. The required AWS headers for AWS SigV4 signing
      *
+     * @param requiresAwsHeaders boolean indicating if the HTTP request needs to be authorized using AWS SigV4
+     * @param requiresAwsSessionHeader boolean indicating if the HTTP request is using temporary AWS credentials (a Session token)
      * @param headerParams The header parameters passed to the original invokeAPI function
      * @return A merged map of multiple headers.
      */

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesChecksumFilter.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesChecksumFilter.java
@@ -57,7 +57,7 @@ public class WesChecksumFilter implements ClientRequestFilter {
         if (wesRequestData.hasCredentials()) {
 
             // If the request requires AWS auth headers, calculate the signature, otherwise just get the standard bearer token
-            final String authorizationHeader = wesRequestData.requiresAwsHeaders()
+            final String authorizationHeader = wesRequestData.usesAwsCredentials()
                 ? generateAwsSignature(requestContext) : wesRequestData.getBearerToken();
 
             // Add this as the Authorization header to the request object

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesRequestData.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesRequestData.java
@@ -150,7 +150,7 @@ public class WesRequestData {
         return this.credentialType == CredentialType.AWS_PERMANENT_CREDENTIALS || this.credentialType == CredentialType.AWS_TEMPORARY_CREDENTIALS;
     }
 
-    public boolean requiresAwsSessionHeaders() {
+    public boolean requiresAwsSessionHeader() {
         return this.credentialType == CredentialType.AWS_TEMPORARY_CREDENTIALS;
     }
 

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/AbstractEntryClientTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/AbstractEntryClientTestIT.java
@@ -303,7 +303,7 @@ public class AbstractEntryClientTestIT {
 
         assertEquals("AWS access key should be parsed", "KEY3", data.getAwsAccessKey());
         assertEquals("AWS secret key should be parsed", "SECRET_KEY3", data.getAwsSecretKey());
-        assertEquals("AWS secret key should be parsed", "TOKEN3", data.getAwsSessionToken());
+        assertEquals("AWS session token should be parsed", "TOKEN3", data.getAwsSessionToken());
         assertEquals("AWS region should be parsed", "REGION3", data.getAwsRegion());
         assertEquals("AWS credentials type should be temporary", WesRequestData.CredentialType.AWS_TEMPORARY_CREDENTIALS, data.getCredentialType());
 

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/AbstractEntryClientTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/AbstractEntryClientTestIT.java
@@ -281,4 +281,32 @@ public class AbstractEntryClientTestIT {
 
     }
 
+    @Test
+    public void testAggregateAWSCredentialSessionToken() {
+
+        AbstractEntryClient workflowClient = testAggregateHelper("configWithAwsSessionProfile");
+
+        String[] args = {
+            "service-info",
+            "--wes-url",
+            "myUrl"
+        };
+
+        String credentials  = ResourceHelpers.resourceFilePath("fakeAwsCredentials2");
+        String config = ResourceHelpers.resourceFilePath("fakeAwsConfig");
+        environmentVariables.set("AWS_CONFIG_FILE", config);
+        environmentVariables.set("AWS_CREDENTIAL_PROFILES_FILE", credentials);
+
+        WesCommandParser parser = new WesCommandParser();
+        parser.jCommander.parse(args);
+        WesRequestData data = workflowClient.aggregateWesRequestData(parser);
+
+        assertEquals("AWS access key should be parsed", "KEY3", data.getAwsAccessKey());
+        assertEquals("AWS secret key should be parsed", "SECRET_KEY3", data.getAwsSecretKey());
+        assertEquals("AWS secret key should be parsed", "TOKEN3", data.getAwsSessionToken());
+        assertEquals("AWS region should be parsed", "REGION3", data.getAwsRegion());
+        assertEquals("AWS credentials type should be temporary", WesRequestData.CredentialType.AWS_TEMPORARY_CREDENTIALS, data.getCredentialType());
+
+    }
+
 }

--- a/dockstore-client/src/test/resources/configWithAwsSessionProfile
+++ b/dockstore-client/src/test/resources/configWithAwsSessionProfile
@@ -1,0 +1,7 @@
+server-url: http://localhost:8080
+
+[WES]
+url: veryveryfakeurl
+type: aws
+authorization: temporaryCreds
+region: somewhere-in-space

--- a/dockstore-client/src/test/resources/fakeAwsConfig
+++ b/dockstore-client/src/test/resources/fakeAwsConfig
@@ -3,3 +3,6 @@ region = REGION
 
 [default]
 region = REGION2
+
+[temporaryCreds]
+region = REGION3

--- a/dockstore-client/src/test/resources/fakeAwsCredentials2
+++ b/dockstore-client/src/test/resources/fakeAwsCredentials2
@@ -5,3 +5,8 @@ aws_secret_access_key = SECRET_KEY
 [default]
 aws_access_key_id = KEY2
 aws_secret_access_key = SECRET_KEY2
+
+[temporaryCreds]
+aws_access_key_id = KEY3
+aws_secret_access_key = SECRET_KEY3
+aws_session_token = TOKEN3


### PR DESCRIPTION
Ticket: https://ucsc-cgl.atlassian.net/browse/SEAB-3477

The AWS `ProfileCredentialsProvider` already parses permanent and temporary credentials from profiles, so this PR just adds functionality to detect and leverage temporary credentials when they are located. 

The CLI will identify this as permanent AWS credentials:
```
[profile]
aws_access_key_id = 123
aws_secret_access_key = 456
```
And this as temporary AWS credentials:
```
[profile]
aws_access_key_id = 123
aws_secret_access_key = 456
aws_session_token = 789
```

For AWS SigV4 authorization, the difference between using permanent and temporary credentials for authentication is a single header: `X-Amz-Security-Token` (More details can be found here: https://docs.aws.amazon.com/general/latest/gr/sigv4-add-signature-to-request.html). So when the CLI identifies temporary credentials, `X-Amz-Security-Token` is added to the WES HTTP request.

- [X] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
