### PR TITLE
minor refactor

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -377,10 +377,13 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
             workflowsApi.getApiClient().setDebugging(Client.DEBUG.get());
             File zipFile = new File(directory, zipFilename(workflow));
             FileUtils.writeByteArrayToFile(zipFile, arbitraryURL, false);
+
+            // If we unzip the file, we can provide a path to the primary descriptor, otherwise just provide a path to the zip file
             if (unzip) {
                 SwaggerUtility.unzipFile(zipFile, directory);
+                return new File(directory, first.get().getWorkflowPath());
             }
-            return new File(directory, first.get().getWorkflowPath());
+            return zipFile;
         } else {
             throw new RuntimeException("version not found");
         }


### PR DESCRIPTION
Minor refactoring for file downloads. The CLI was returning the expected path to downloaded primary descriptors (in temporary directories) regardless of whether or not the file actually exists. In the case where we do not automatically unzip the directory, the primary descriptor would not be present, so we should return the existing zip file instead.

- [X] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
