### PR TITLE
API parameter is required to be non-null.

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesLauncher.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesLauncher.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 
 import io.dockstore.openapi.client.ApiClient;
 import io.dockstore.openapi.client.ApiException;
+import io.dockstore.openapi.client.model.WorkflowSubClass;
 import io.openapi.wes.client.model.RunId;
 import io.swagger.client.model.Workflow;
 import io.swagger.client.model.WorkflowVersion;
@@ -113,7 +114,7 @@ public final class WesLauncher {
         String[] parts = workflowEntry.split(":");
         String path = parts[0];
         String version = workflowClient.getVersionID(workflowEntry);
-        return workflowClient.getWorkflowsApi().getPublishedWorkflowByPath(path, WorkflowClient.BIOWORKFLOW, null, version);
+        return workflowClient.getWorkflowsApi().getPublishedWorkflowByPath(path, WorkflowSubClass.BIOWORKFLOW.toString(), null, version);
     }
 
     /**

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesLauncher.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesLauncher.java
@@ -100,7 +100,7 @@ public final class WesLauncher {
         String[] parts = workflowEntry.split(":");
         String path = parts[0];
         String version = workflowClient.getVersionID(workflowEntry);
-        return workflowClient.getWorkflowsApi().getPublishedWorkflowByPath(path, null, null, version);
+        return workflowClient.getWorkflowsApi().getPublishedWorkflowByPath(path, WorkflowClient.BIOWORKFLOW, null, version);
     }
 
     /**

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WesLauncherIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WesLauncherIT.java
@@ -103,7 +103,7 @@ public class WesLauncherIT {
         // WorkflowsApi Function mocks
         when(workflowApi.getPublishedWorkflowByPath(
             any(String.class),
-            ArgumentMatchers.isNull(),
+            any(String.class),
             ArgumentMatchers.isNull(),
             any(String.class)
         )).thenReturn(fakeWorkflow);


### PR DESCRIPTION
Followup to: https://github.com/dockstore/dockstore-cli/pull/107

This parameter is now required to be non-null. There are two separate 'bioworkflow' strings to choose from:
1. `WorkflowSubClass.BIOWORKFLOW.toString()` -> `"BIOWORKFLOW"`
2. `WorkflowClient.BIOWORKFLOW` -> `"bioworkflow"`

I see `WorkflowSubClass.BIOWORKFLOW.toString()` being used to make the same function call [elsewhere](https://github.com/dockstore/dockstore-cli/pull/107/files#diff-e679fea995a50bafa2ef51b5d382128204370e4a29ef6509d0e2271a89dc3981), so I'm opting for it here, but both are used throughout the CLI. Either seems to work. Is there an important difference between the two? I believe both are processed as case-insensitive.

This parameter

- [X] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
