### PR TITLE
Feature/3831/add wes list runs

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -69,6 +69,7 @@ import io.github.collaboratory.nextflow.NextflowClient;
 import io.github.collaboratory.wdl.WDLClient;
 import io.openapi.wes.client.api.WorkflowExecutionServiceApi;
 import io.openapi.wes.client.model.RunId;
+import io.openapi.wes.client.model.RunListResponse;
 import io.openapi.wes.client.model.RunLog;
 import io.openapi.wes.client.model.RunStatus;
 import io.openapi.wes.client.model.ServiceInfo;
@@ -1141,6 +1142,19 @@ public abstract class AbstractEntryClient<T> {
     }
 
     /**
+     * This will attempt to retrieve information regarding the WES server
+     * @param clientWorkflowExecutionServiceApi The API client
+     */
+    private void wesListRuns(int pageSize, String pageToken, WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi) {
+        try {
+            RunListResponse response = clientWorkflowExecutionServiceApi.listRuns((long)pageSize, pageToken);
+            out("WES Run List: " + response.toString());
+        } catch (io.openapi.wes.client.ApiException e) {
+            LOG.error("Error getting WES Run List", e);
+        }
+    }
+
+    /**
      * Given the parsed command object, determine if we are to print help commands
      * @param wesCommandParser Parse commands
      * @return true if help was displayed, false otherwise
@@ -1161,6 +1175,9 @@ public abstract class AbstractEntryClient<T> {
             return true;
         } else if (wesCommandParser.commandServiceInfo.isHelp()) {
             wesServiceInfoHelp();
+            return true;
+        } else if (wesCommandParser.commandRunList.isHelp()) {
+            wesRunListHelp();
             return true;
         }
 
@@ -1204,6 +1221,11 @@ public abstract class AbstractEntryClient<T> {
                 break;
             case "service-info":
                 wesServiceInfo(clientWorkflowExecutionServiceApi);
+                break;
+            case "list":
+                wesListRuns(wesCommandParser.commandRunList.getPageSize(),
+                    wesCommandParser.commandRunList.getPageToken(),
+                    clientWorkflowExecutionServiceApi);
                 break;
             default:
                 errorMessage("Unknown WES command.", CLIENT_ERROR);
@@ -1473,6 +1495,7 @@ public abstract class AbstractEntryClient<T> {
         out("       dockstore " + getEntryType().toLowerCase() + " wes status [parameters]");
         out("       dockstore " + getEntryType().toLowerCase() + " wes cancel [parameters]");
         out("       dockstore " + getEntryType().toLowerCase() + " wes service-info [parameters]");
+        out("       dockstore " + getEntryType().toLowerCase() + " wes list [parameters]");
         out("");
         out("Description:");
         out(" Sends a request to a Workflow Execution Service (WES) endpoint.");
@@ -1540,6 +1563,21 @@ public abstract class AbstractEntryClient<T> {
         out("");
         out("Description:");
         out("  Returns descriptive information of the provided WES server. ");
+        printWesHelpFooter();
+        printHelpFooter();
+    }
+
+    private void wesRunListHelp() {
+        printHelpHeader();
+        out("Usage: dockstore " + getEntryType().toLowerCase() + " wes list --help");
+        out("       dockstore " + getEntryType().toLowerCase() + " wes list");
+        out("");
+        out("Description:");
+        out("  Returns information about past runs. ");
+        out("Optional Parameters:");
+        out("  --count                           The number of runs to list.");
+        out("  --page-token                      A page token provided from a previous list of runs.");
+        out("");
         printWesHelpFooter();
         printHelpFooter();
     }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -1143,6 +1143,8 @@ public abstract class AbstractEntryClient<T> {
 
     /**
      * This will attempt to retrieve information regarding the WES server
+     * @param pageSize The number of entries to return
+     * @param pageToken The returned page token from a previous call of ListRuns
      * @param clientWorkflowExecutionServiceApi The API client
      */
     private void wesListRuns(int pageSize, String pageToken, WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi) {

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
@@ -13,6 +13,7 @@ public class WesCommandParser {
     public CommandCancel commandCancel;
     public CommandStatus commandStatus;
     public CommandServiceInfo commandServiceInfo;
+    public CommandRunList commandRunList;
     public JCommander jCommander;
 
     public WesCommandParser() {
@@ -21,6 +22,7 @@ public class WesCommandParser {
         this.commandCancel = new CommandCancel();
         this.commandStatus = new CommandStatus();
         this.commandServiceInfo = new CommandServiceInfo();
+        this.commandRunList = new CommandRunList();
 
         this.jCommander = buildWesCommandParser();
     }
@@ -34,6 +36,7 @@ public class WesCommandParser {
             .addCommand("cancel", this.commandCancel)
             .addCommand("status", this.commandStatus)
             .addCommand("service-info", this.commandServiceInfo)
+            .addCommand("list", this.commandRunList)
             .build();
     }
 
@@ -103,6 +106,24 @@ public class WesCommandParser {
 
     @Parameters(separators = "=", commandDescription = "Retrieve info about a WES server")
     public static class CommandServiceInfo extends WesMain {
+    }
+
+    @Parameters(separators = "=", commandDescription = "Retrieve a list of runs")
+    public static class CommandRunList extends WesMain {
+        private static final int DEFAULT_PAGE_SIZE = 10;
+
+        @Parameter(names = "--count", description = "The number of entries to print")
+        private int pageSize = DEFAULT_PAGE_SIZE;
+        @Parameter(names = "--page-token", description = "The page token returned from a previous list of runs")
+        private String pageToken = null;
+
+        public int getPageSize() {
+            return pageSize;
+        }
+
+        public String getPageToken() {
+            return pageToken;
+        }
     }
 
 }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
@@ -40,7 +40,7 @@ public class WesCommandParser {
             .build();
     }
 
-    @Parameters(separators = "=", commandDescription = "Execute WES commands")
+    @Parameters(commandDescription = "Execute WES commands")
     public static class WesMain {
         @Parameter(names = "--wes-url", description = "The URL of the WES server.", required = false)
         private String wesUrl = null;
@@ -56,7 +56,7 @@ public class WesCommandParser {
         }
     }
 
-    @Parameters(separators = "=", commandDescription = "Launch a workflow using WES")
+    @Parameters(commandDescription = "Launch a workflow using WES")
     public static class CommandLaunch extends WesMain {
         @Parameter(names = "--entry", description = "Complete workflow path in Dockstore (ex. NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq:master)", required = true)
         private String entry;
@@ -78,7 +78,7 @@ public class WesCommandParser {
         }
     }
 
-    @Parameters(separators = "=", commandDescription = "Cancel a remote WES entry")
+    @Parameters(commandDescription = "Cancel a remote WES entry")
     public static class CommandCancel extends WesMain {
         @Parameter(names = "--id", description = "The ID of the workflow to cancel", required = true)
         private String id;
@@ -88,7 +88,7 @@ public class WesCommandParser {
         }
     }
 
-    @Parameters(separators = "=", commandDescription = "Retrieve the status of a workflow")
+    @Parameters(commandDescription = "Retrieve the status of a workflow")
     public static class CommandStatus extends WesMain {
         @Parameter(names = "--id", description = "The ID of the workflow to cancel", required = true)
         private String id;
@@ -104,11 +104,11 @@ public class WesCommandParser {
         }
     }
 
-    @Parameters(separators = "=", commandDescription = "Retrieve info about a WES server")
+    @Parameters(commandDescription = "Retrieve info about a WES server")
     public static class CommandServiceInfo extends WesMain {
     }
 
-    @Parameters(separators = "=", commandDescription = "Retrieve a list of runs")
+    @Parameters(commandDescription = "Retrieve a list of runs")
     public static class CommandRunList extends WesMain {
         private static final int DEFAULT_PAGE_SIZE = 10;
 

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
@@ -6,6 +6,7 @@ import io.dockstore.client.cli.nested.WesCommandParser;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -268,5 +269,37 @@ public class WesCommandParserTest {
         JCommander parser = wesCommandParser.jCommander;
         parser.parse(args);
         assertTrue("Help should be set", wesCommandParser.commandServiceInfo.isHelp());
+    }
+
+    @Test
+    public void testCommandRunListHelp() {
+        final String[] args = {
+            "list",
+            "--help"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        parser.parse(args);
+        assertTrue("Help should be set", wesCommandParser.commandRunList.isHelp());
+    }
+
+    @Test
+    public void testCommandRunList() {
+        final String[] args = {
+            "list",
+            "--count",
+            "3",
+            "--page-token",
+            "banana"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        parser.parse(args);
+        assertFalse("Help should be set", wesCommandParser.commandRunList.isHelp());
+        assertEquals("Count should be set to 3", 3, wesCommandParser.commandRunList.getPageSize());
+        assertEquals("Page token should be set to 'banana'", "banana", wesCommandParser.commandRunList.getPageToken());
+
     }
 }

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
@@ -286,10 +286,11 @@ public class WesCommandParserTest {
 
     @Test
     public void testCommandRunList() {
+        final int count = 3;
         final String[] args = {
             "list",
             "--count",
-            "3",
+            String.valueOf(count),
             "--page-token",
             "banana"
         };
@@ -298,7 +299,7 @@ public class WesCommandParserTest {
         JCommander parser = wesCommandParser.jCommander;
         parser.parse(args);
         assertFalse("Help should be set", wesCommandParser.commandRunList.isHelp());
-        assertEquals("Count should be set to 3", 3, wesCommandParser.commandRunList.getPageSize());
+        assertEquals("Count should be set to 3", count, wesCommandParser.commandRunList.getPageSize());
         assertEquals("Page token should be set to 'banana'", "banana", wesCommandParser.commandRunList.getPageToken());
 
     }


### PR DESCRIPTION
Implements the WES `ListRuns` functionality for the CLI. (https://ucsc-cgl.atlassian.net/browse/SEAB-3831)

When testing against AGC, it seems the `pageSize` input is being ignored, and a list of approximately 15 entries is returned. The parameter seems to be getting passed correctly in the HTTP request, and I can verify via CloudWatch it's received so I'm not certain if the issue is on the CLI's end or the WES server, I'll reach out separately.

The current output looks as follows (We have a followup ticket to improve the print visuals):
```
WES Run List: class RunListResponse {
    runs: [class RunStatus {
        runId: 82f1bc68-0e3b-49a6-8416-c32d24b36f7a
        state: COMPLETE
    }, class RunStatus {
        runId: 31c5d471-b7c8-4039-b954-54e60648f9b8
        state: COMPLETE
    }, class RunStatus {
        runId: 74d45f55-0e39-4022-b495-a6bb92aff7b9
        state: EXECUTOR_ERROR
    }]
    nextPageToken: null
}
```

Note: There is a Snyk failure on this PR, it looks like 2 poms failed to process (which is odd because no poms were changed), no action items as this is a false positive.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [X] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
