### PR TITLE
Improved WES exception handling

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
@@ -1,7 +1,6 @@
 package io.dockstore.client.cli.nested;
 
 import java.io.File;
-import java.net.UnknownHostException;
 import java.text.DateFormat;
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
@@ -244,7 +244,7 @@ public class ApiClientExtended extends ApiClient {
             // This could be caused by a failed Jersey Interceptor/filter, missing message body writers, or other IO exceptions.
             // Mainly, this error is thrown when the provided WES URL is invalid. For more details, see:
             // https://docs.oracle.com/javaee/7/api/index.html?javax/ws/rs/ProcessingException.html
-            errorMessage(MessageFormat.format("There was an error processing the HTTP request. This could be caused by an invalid URL: {0}",
+            errorMessage(MessageFormat.format("There was an error processing the HTTP request: {0}",
                 ex.getMessage()), Client.CONNECTION_ERROR);
             return null;
         } catch (ApiException ex) {

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
@@ -264,7 +264,7 @@ public class ApiClientExtended extends ApiClient {
                     ex.getCode(), ex.getMessage()), Client.API_ERROR);
                 break;
             case HttpStatus.SC_NOT_FOUND:
-                errorMessage(MessageFormat.format("[{0}] The WES server was unable to locate the target entry: {1}",
+                errorMessage(MessageFormat.format("[{0}] The WES server was unable to locate an entity: {1}",
                     ex.getCode(), ex.getMessage()), Client.API_ERROR);
                 break;
             case HttpStatus.SC_INTERNAL_SERVER_ERROR:

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
@@ -252,28 +252,28 @@ public class ApiClientExtended extends ApiClient {
             // message and the message provided from the WES server in the printed error.
             switch (ex.getCode()) {
             case HttpStatus.SC_BAD_REQUEST:
-                errorMessage(MessageFormat.format("The WES request was malformed: {0}",
-                    ex.getMessage()), Client.API_ERROR);
+                errorMessage(MessageFormat.format("[{0}] The WES request was malformed: {1}",
+                    ex.getCode(), ex.getMessage()), Client.API_ERROR);
                 break;
             case HttpStatus.SC_UNAUTHORIZED:
-                errorMessage(MessageFormat.format("The WES request is unauthorized to be performed on the target WES server: {0}",
-                    ex.getMessage()), Client.API_ERROR);
+                errorMessage(MessageFormat.format("[{0}] The WES request is unauthorized to be performed on the target WES server: {1}",
+                    ex.getCode(), ex.getMessage()), Client.API_ERROR);
                 break;
             case HttpStatus.SC_FORBIDDEN:
-                errorMessage(MessageFormat.format("The provided credentials are not authorized to make this WES request: {0}",
-                    ex.getMessage()), Client.API_ERROR);
+                errorMessage(MessageFormat.format("[{0}] The provided credentials are not authorized to make this WES request: {1}",
+                    ex.getCode(), ex.getMessage()), Client.API_ERROR);
                 break;
             case HttpStatus.SC_NOT_FOUND:
-                errorMessage(MessageFormat.format("The WES server was unable to locate the target entry: {0}",
-                    ex.getMessage()), Client.API_ERROR);
+                errorMessage(MessageFormat.format("[{0}] The WES server was unable to locate the target entry: {1}",
+                    ex.getCode(), ex.getMessage()), Client.API_ERROR);
                 break;
             case HttpStatus.SC_INTERNAL_SERVER_ERROR:
-                errorMessage(MessageFormat.format("There was an internal server error processing this WES request: {0}",
-                    ex.getMessage()), Client.API_ERROR);
+                errorMessage(MessageFormat.format("[{0}] There was an internal server error processing this WES request: {1}",
+                    ex.getCode(), ex.getMessage()), Client.API_ERROR);
                 break;
             default:
-                errorMessage(MessageFormat.format("There was an unknown error processing this WES request: {0}",
-                    ex.getMessage()), Client.API_ERROR);
+                errorMessage(MessageFormat.format("[{0}] There was an unknown error processing this WES request: {1}",
+                    ex.getCode(), ex.getMessage()), Client.API_ERROR);
             }
 
             return null;

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
@@ -244,7 +244,8 @@ public class ApiClientExtended extends ApiClient {
             // This could be caused by a failed Jersey Interceptor/filter, missing message body writers, or other IO exceptions.
             // Mainly, this error is thrown when the provided WES URL is invalid. For more details, see:
             // https://docs.oracle.com/javaee/7/api/index.html?javax/ws/rs/ProcessingException.html
-            errorMessage(ex.getMessage(), Client.CONNECTION_ERROR);
+            errorMessage(MessageFormat.format("There was an error processing the HTTP request. This could be caused by an invalid URL: {0}",
+                ex.getMessage()), Client.CONNECTION_ERROR);
             return null;
         } catch (ApiException ex) {
             // Different WES servers provide error messages with different levels of verbosity/usefulness, so include both a default
@@ -252,27 +253,27 @@ public class ApiClientExtended extends ApiClient {
             switch (ex.getCode()) {
             case HttpStatus.SC_BAD_REQUEST:
                 errorMessage(MessageFormat.format("The WES request was malformed: {0}",
-                    ex.getLocalizedMessage()), Client.API_ERROR);
+                    ex.getMessage()), Client.API_ERROR);
                 break;
             case HttpStatus.SC_UNAUTHORIZED:
                 errorMessage(MessageFormat.format("The WES request is unauthorized to be performed on the target WES server: {0}",
-                    ex.getLocalizedMessage()), Client.API_ERROR);
+                    ex.getMessage()), Client.API_ERROR);
                 break;
             case HttpStatus.SC_FORBIDDEN:
                 errorMessage(MessageFormat.format("The provided credentials are not authorized to make this WES request: {0}",
-                    ex.getLocalizedMessage()), Client.API_ERROR);
+                    ex.getMessage()), Client.API_ERROR);
                 break;
             case HttpStatus.SC_NOT_FOUND:
                 errorMessage(MessageFormat.format("The WES server was unable to locate the target entry: {0}",
-                    ex.getLocalizedMessage()), Client.API_ERROR);
+                    ex.getMessage()), Client.API_ERROR);
                 break;
             case HttpStatus.SC_INTERNAL_SERVER_ERROR:
                 errorMessage(MessageFormat.format("There was an internal server error processing this WES request: {0}",
-                    ex.getLocalizedMessage()), Client.API_ERROR);
+                    ex.getMessage()), Client.API_ERROR);
                 break;
             default:
                 errorMessage(MessageFormat.format("There was an unknown error processing this WES request: {0}",
-                    ex.getLocalizedMessage()), Client.API_ERROR);
+                    ex.getMessage()), Client.API_ERROR);
             }
 
             return null;

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
@@ -1,6 +1,7 @@
 package io.dockstore.client.cli.nested;
 
 import java.io.File;
+import java.net.UnknownHostException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -10,6 +11,7 @@ import java.util.Optional;
 import java.util.TimeZone;
 import java.util.TreeMap;
 
+import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
@@ -19,6 +21,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.dockstore.client.cli.Client;
 import io.openapi.wes.client.ApiClient;
 import io.openapi.wes.client.ApiException;
 import io.openapi.wes.client.Pair;
@@ -30,6 +33,7 @@ import uk.co.lucasweb.aws.v4.signer.HttpRequest;
 import uk.co.lucasweb.aws.v4.signer.Signer;
 import uk.co.lucasweb.aws.v4.signer.credentials.AwsCredentials;
 
+import static io.dockstore.client.cli.ArgumentUtility.errorMessage;
 import static io.dockstore.client.cli.ArgumentUtility.out;
 
 public class ApiClientExtended extends ApiClient {
@@ -236,6 +240,9 @@ public class ApiClientExtended extends ApiClient {
                     buildResponseHeaders(response),
                     respBody);
             }
+        } catch (ProcessingException ex) {
+            errorMessage(ex.getMessage(), Client.CONNECTION_ERROR);
+            return null;
         } finally {
             try {
                 response.close();

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ApiClientExtended.java
@@ -262,6 +262,10 @@ public class ApiClientExtended extends ApiClient {
                 errorMessage(MessageFormat.format("The provided credentials are not authorized to make this WES request: {0}",
                     ex.getLocalizedMessage()), Client.API_ERROR);
                 break;
+            case HttpStatus.SC_NOT_FOUND:
+                errorMessage(MessageFormat.format("The WES server was unable to locate the target entry: {0}",
+                    ex.getLocalizedMessage()), Client.API_ERROR);
+                break;
             case HttpStatus.SC_INTERNAL_SERVER_ERROR:
                 errorMessage(MessageFormat.format("There was an internal server error processing this WES request: {0}",
                     ex.getLocalizedMessage()), Client.API_ERROR);


### PR DESCRIPTION
Ticket: https://ucsc-cgl.atlassian.net/browse/SEAB-3487

This PR introduces some additional exception handling for the WES functionality. Based on the WES API calls, the list of status codes (https://ga4gh.github.io/workflow-execution-service-schemas/docs/#tag/WorkflowExecutionService) we can expect to receive from a WES server includes: 

1. OK: `200`
2. Malformed: `400`
3. Request is unauthorized: `401`
4. Requester is unauthorized: `403`
5. Target not found: `404`
6. Internal server error: `500`

I found that between DNAStack and AGC WES servers, some of the error messages were either in odd formats or not verbose (For example, in the case of a `403`, DNAStack returns the message `error`, and AGC returns the JSON string `{"message":"The security token included in the request is expired"}`). To make sure our error messages are descriptive, I search for each request status code and print out a default descriptive message along with the message provided by the server.

Also, it looks like Jersey throws a `ProcessingException` if the WES URL can't be resolved, so we catch that as well to give a descriptive error message.


Please make sure that you've checked the following before submitting your pull request. Thanks!

- [X] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
