### PR TITLE
Don't throw error message if Jar already present

### DIFF
--- a/dockstore-client/bin/dockstore
+++ b/dockstore-client/bin/dockstore
@@ -157,7 +157,7 @@ if [ "$1" = "self-install" ]; then
     if [ -r "$DOCKSTORE_JAR" ]; then
         echo "The self-install jar already exists at $DOCKSTORE_JAR."
         echo "If you wish to re-download, delete it and rerun \"$0 self-install\"."
-        exit 1
+        exit 0
     fi
 
     (>&2 echo "Downloading Dockstore to $DOCKSTORE_JAR now...")

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -42,7 +42,6 @@ import ch.qos.logback.classic.Level;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
-import com.google.common.io.ByteStreams;
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
 import io.cwl.avro.CWL;

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -354,8 +354,8 @@ public class Client {
             // was run to upgrade the Dockstore version.
             Map<String, String> additionalEnvVarMap =
                     Collections.singletonMap("DOCKSTORE_VERSION", dockstoreVersion);
-            Utilities.executeCommand(file.toPath().toString() + " self-install", ByteStreams.nullOutputStream(),
-                     ByteStreams.nullOutputStream(), null, additionalEnvVarMap);
+            Utilities.executeCommand(file.toPath().toString() + " self-install",
+                    System.out, System.err, null, additionalEnvVarMap);
         } catch (IOException e) {
             exceptionMessage(e, "Could not connect to Github. You may have reached your rate limit.", IO_ERROR);
         }


### PR DESCRIPTION
Addresses https://ucsc-cgl.atlassian.net/browse/SEAB-3147
Upgrading CLI from 1.10.0 to 1.11.0 works but throws error message
Return the stdout and stderr so you can see message from dockstore script
Don't report a failure just because the JAR is already there.