### PR TITLE
Feature/dock 1851/cli attempts erroneous file download

### DIFF
--- a/dockstore-client/src/main/java/io/github/collaboratory/cwl/CWLClient.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/cwl/CWLClient.java
@@ -609,13 +609,17 @@ public class CWLClient extends BaseLanguageClient implements LanguageClientInter
     private List<Pair<String, Path>> processArrayofArrayOfFiles(Object entry, Map.Entry<String, Object> stringObjectEntry,
             String cwlInputFileID, Map<String, FileProvisioning.FileInfo> fileMap, List<String> secondaryFiles) {
         List<Pair<String, Path>> inputSet = new ArrayList<>();
-        ArrayList<Map> filesArray = (ArrayList)entry;
-        for (Map file : filesArray) {
-            String path = getPathOrLocation(file);
-            // notice I'm putting key:path together so they are unique in the hash
-            if (path != null && stringObjectEntry.getKey().equals(cwlInputFileID)) {
-                inputSet.addAll(doProcessFile(stringObjectEntry.getKey() + ":" + path, path, cwlInputFileID, fileMap, secondaryFiles));
+        try {
+            ArrayList<Map> filesArray = (ArrayList)entry;
+            for (Map file : filesArray) {
+                String path = getPathOrLocation(file);
+                // notice I'm putting key:path together so they are unique in the hash
+                if (path != null && stringObjectEntry.getKey().equals(cwlInputFileID)) {
+                    inputSet.addAll(doProcessFile(stringObjectEntry.getKey() + ":" + path, path, cwlInputFileID, fileMap, secondaryFiles));
+                }
             }
+        } catch (ClassCastException e) {
+            LOG.warn("This is not an array of array of files, it may be an array of array of strings");
         }
         return inputSet;
     }


### PR DESCRIPTION
**Description**
This PR adds a missing null check to the code that determines which input files a workflow needs to run.  Without the null check, if the code encountered an input field with a map value, and said map did not include either a `path` or `location` key, the cli would attempt to manipulate a null path and die.  

I also did a small amount of refactoring.  I wasn't sure if we try to sync the CLI release with the webservice/UI, so I didn't want to change much...

Now, the workflow described in the issue fails with a different, legitimate error, due to a missing input:

`19:34:34.223 [pool-2-thread-1] ERROR io.dockstore.common.FileProvisioning - Could not copy /mnt/data/ucsd-dartfish/ex1/0_Raw_chcorr/ to /Users/svonworl/tmp/spatial-transcriptomics-pipeline/datastore/launcher-5e3038e8-0389-48c6-a3e6-f242c3d403b0/inputs/00712025-d897-4883-8c1c-0f3ad17c86eb/0_Raw_chcorr`

Some of the surrounding code feels a bit rickety.  If we want to improve our CWL support, we should gather together a diverse set of runnable CWL workflows and make sure they are processed correctly by both the CLI and webservice.   There's probably more bugs like this scattered about.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-1851
dockstore/dockstore#4341

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
