### PR TITLE
Feature/4709/wesVerboseMode

### DIFF
--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WesToilIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WesToilIT.java
@@ -30,15 +30,24 @@ public class WesToilIT {
     public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
 
     /**
-     * Searches for a runId in the provided string using a pattern printed by the CLI during a launch
+     * Searches for a runId in the provided string using a pattern printed by the CLI during a launch. Only needed for verbose outputs.
      * @param runLog The String to search for the runId in
-     * @return
+     * @return String run ID
      */
-    private String findWorkflowId(String runLog) {
+    private String findWorkflowIdFromVerboseLaunch(String runLog) {
         // This is pretty ugly, but we don't present the workflow ID in an clean format.
         int runIdIndex = runLog.indexOf(RUN_ID_PATTERN_PREFIX);
         int newlineFromRunId = runLog.indexOf("\n", runIdIndex);
         return runLog.substring(runIdIndex + RUN_ID_PATTERN_PREFIX.length(), newlineFromRunId).trim();
+    }
+
+    /**
+     * When not using verbose logging, the runId should just be "{ID}\n"
+     * @param runLog The String to search for the runId in
+     * @return String run ID
+     */
+    private String findWorkflowIdFromNonVerboseLaunch(String runLog) {
+        return runLog.trim();
     }
 
     /**
@@ -77,9 +86,8 @@ public class WesToilIT {
             "--inline-workflow"
         };
         Client.main(commandStatementRun);
-        assertTrue("A helper command should be printed to stdout when a workflow is successfully started", systemOutRule.getLog().contains("dockstore workflow wes status --id"));
 
-        final String runId = findWorkflowId(systemOutRule.getLog());
+        final String runId = findWorkflowIdFromNonVerboseLaunch(systemOutRule.getLog());
         final boolean isSuccessful = waitForWorkflowState(runId, COMPLETED_STATE);
 
         assertTrue("The workflow did not succeed in time.", isSuccessful);
@@ -91,12 +99,13 @@ public class WesToilIT {
             "--config", TOIL_CONFIG,
             "--entry", "github.com/dockstore-testing/wes-testing/multi-descriptor-no-input:main",
             "--json", ResourceHelpers.resourceFilePath("wesIt/w1_test.json"), // Toil requires workflow_params to be provided
-            "--inline-workflow"
+            "--inline-workflow",
+            "--verbose"
         };
         Client.main(commandStatementRun);
         assertTrue("A helper command should be printed to stdout when a workflow is successfully started", systemOutRule.getLog().contains("dockstore workflow wes status --id"));
 
-        final String runId = findWorkflowId(systemOutRule.getLog());
+        final String runId = findWorkflowIdFromVerboseLaunch(systemOutRule.getLog());
         final boolean isError = waitForWorkflowState(runId, EXECUTOR_ERROR_STATE);
 
         // Toil does not support imports at this time, so multi-descriptor workflows should fail.
@@ -113,9 +122,8 @@ public class WesToilIT {
             "--inline-workflow"
         };
         Client.main(commandStatementRun);
-        assertTrue("A helper command should be printed to stdout when a workflow is successfully started", systemOutRule.getLog().contains("dockstore workflow wes status --id"));
 
-        final String runId = findWorkflowId(systemOutRule.getLog());
+        final String runId = findWorkflowIdFromNonVerboseLaunch(systemOutRule.getLog());
         final boolean isSuccessful = waitForWorkflowState(runId, COMPLETED_STATE);
 
         assertTrue("The workflow did not succeed in time.", isSuccessful);
@@ -130,9 +138,8 @@ public class WesToilIT {
             "--inline-workflow"
         };
         Client.main(commandStatementRun);
-        assertTrue("A helper command should be printed to stdout when a workflow is successfully started", systemOutRule.getLog().contains("dockstore workflow wes status --id"));
 
-        final String runId = findWorkflowId(systemOutRule.getLog());
+        final String runId = findWorkflowIdFromNonVerboseLaunch(systemOutRule.getLog());
 
         String[] commandStatementCancel = new String[]{ "workflow", "wes", "cancel",
             "--config", TOIL_CONFIG,

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WesToilIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WesToilIT.java
@@ -46,7 +46,7 @@ public class WesToilIT {
      * @param runLog The String to search for the runId in
      * @return String run ID
      */
-    private String findWorkflowIdFromNonVerboseLaunch(String runLog) {
+    private String findWorkflowIdFromDefaultLaunch(String runLog) {
         return runLog.trim();
     }
 
@@ -87,7 +87,7 @@ public class WesToilIT {
         };
         Client.main(commandStatementRun);
 
-        final String runId = findWorkflowIdFromNonVerboseLaunch(systemOutRule.getLog());
+        final String runId = findWorkflowIdFromDefaultLaunch(systemOutRule.getLog());
         final boolean isSuccessful = waitForWorkflowState(runId, COMPLETED_STATE);
 
         assertTrue("The workflow did not succeed in time.", isSuccessful);
@@ -123,7 +123,7 @@ public class WesToilIT {
         };
         Client.main(commandStatementRun);
 
-        final String runId = findWorkflowIdFromNonVerboseLaunch(systemOutRule.getLog());
+        final String runId = findWorkflowIdFromDefaultLaunch(systemOutRule.getLog());
         final boolean isSuccessful = waitForWorkflowState(runId, COMPLETED_STATE);
 
         assertTrue("The workflow did not succeed in time.", isSuccessful);
@@ -139,7 +139,7 @@ public class WesToilIT {
         };
         Client.main(commandStatementRun);
 
-        final String runId = findWorkflowIdFromNonVerboseLaunch(systemOutRule.getLog());
+        final String runId = findWorkflowIdFromDefaultLaunch(systemOutRule.getLog());
 
         String[] commandStatementCancel = new String[]{ "workflow", "wes", "cancel",
             "--config", TOIL_CONFIG,

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -1095,25 +1095,28 @@ public abstract class AbstractEntryClient<T> {
     /**
      *  This will attempt to retrieve the status of a workflow run
      * @param workflowId The ID of the workflow we are getting status info for
-     * @param verbose Whether or not we want verbose logs
      * @param clientWorkflowExecutionServiceApi The API client
      */
-    private void wesStatus(WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi, final String workflowId, final boolean verbose) {
-        out("Getting status of WES workflow");
-        if (verbose) {
-            try {
-                RunLog response = clientWorkflowExecutionServiceApi.getRunLog(workflowId);
-                out("Verbose run status is: " + response.toString());
-            } catch (io.openapi.wes.client.ApiException e) {
-                LOG.error("Error getting verbose WES run status", e);
-            }
-        } else {
-            try {
-                RunStatus response = clientWorkflowExecutionServiceApi.getRunStatus(workflowId);
-                out("Brief run status is: " + response.toString());
-            } catch (io.openapi.wes.client.ApiException e) {
-                LOG.error("Error getting brief WES run status", e);
-            }
+    private void wesStatus(WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi, final String workflowId) {
+        try {
+            RunStatus response = clientWorkflowExecutionServiceApi.getRunStatus(workflowId);
+            out("Brief run status is: " + response.toString());
+        } catch (io.openapi.wes.client.ApiException e) {
+            LOG.error("Error getting brief WES run status", e);
+        }
+    }
+
+    /**
+     *  This will attempt to retrieve the status of a workflow run
+     * @param workflowId The ID of the workflow we are getting status info for
+     * @param clientWorkflowExecutionServiceApi The API client
+     */
+    private void wesRunLogs(WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi, final String workflowId) {
+        try {
+            RunLog response = clientWorkflowExecutionServiceApi.getRunLog(workflowId);
+            out("Verbose run status is: " + response.toString());
+        } catch (io.openapi.wes.client.ApiException e) {
+            LOG.error("Error getting verbose WES run status", e);
         }
     }
 
@@ -1176,6 +1179,9 @@ public abstract class AbstractEntryClient<T> {
         } else if (wesCommandParser.commandStatus.isHelp()) {
             wesStatusHelp();
             return true;
+        } else if (wesCommandParser.commandRunLogs.isHelp()) {
+            wesRunLogsHelp();
+            return true;
         } else if (wesCommandParser.commandCancel.isHelp()) {
             wesCancelHelp();
             return true;
@@ -1224,8 +1230,11 @@ public abstract class AbstractEntryClient<T> {
                 break;
             case "status":
                 wesStatus(clientWorkflowExecutionServiceApi,
-                    wesCommandParser.commandStatus.getId(),
-                    wesCommandParser.commandStatus.isVerbose());
+                    wesCommandParser.commandStatus.getId());
+                break;
+            case "logs":
+                wesRunLogs(clientWorkflowExecutionServiceApi,
+                    wesCommandParser.commandStatus.getId());
                 break;
             case "cancel":
                 wesCancel(clientWorkflowExecutionServiceApi,
@@ -1505,6 +1514,7 @@ public abstract class AbstractEntryClient<T> {
         out("Usage: dockstore " + getEntryType().toLowerCase() + " wes --help");
         out("       dockstore " + getEntryType().toLowerCase() + " wes launch [parameters]");
         out("       dockstore " + getEntryType().toLowerCase() + " wes status [parameters]");
+        out("       dockstore " + getEntryType().toLowerCase() + " wes logs [parameters]");
         out("       dockstore " + getEntryType().toLowerCase() + " wes cancel [parameters]");
         out("       dockstore " + getEntryType().toLowerCase() + " wes service-info [parameters]");
         out("       dockstore " + getEntryType().toLowerCase() + " wes list [parameters]");
@@ -1549,8 +1559,20 @@ public abstract class AbstractEntryClient<T> {
         out("  Status, gets the status of a " + getEntryType() + ".");
         out("Required Parameters:");
         out("  --id <id>                           Id of a run at the WES endpoint, e.g. id returned from the launch command");
-        out("Optional Parameters:");
-        out("  --verbose                           Provide extra status information");
+        out("");
+        printWesHelpFooter();
+        printHelpFooter();
+    }
+
+    private void wesRunLogsHelp() {
+        printHelpHeader();
+        out("Usage: dockstore " + getEntryType().toLowerCase() + " wes logs --help");
+        out("       dockstore " + getEntryType().toLowerCase() + " wes logs [parameters]");
+        out("");
+        out("Description:");
+        out("  Logs, gets the verbose run logs of a " + getEntryType() + ".");
+        out("Required Parameters:");
+        out("  --id <id>                           Id of a run at the WES endpoint, e.g. id returned from the launch command");
         out("");
         printWesHelpFooter();
         printHelpFooter();

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -1225,10 +1225,15 @@ public abstract class AbstractEntryClient<T> {
             setWesRequestData(requestData);
             WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi = getWorkflowExecutionServiceApi();
 
-            JCommander wutIsHappennin = wesCommandParser.jCommander.getCommands().get(wesCommandParser.jCommander.getParsedCommand());
+            // All Wes commands are parsed as subclasses of WesMain. W
+            WesCommandParser.WesMain parsedCommand = (WesCommandParser.WesMain) wesCommandParser.jCommander.getCommands()
+                .get(wesCommandParser.jCommander.getParsedCommand())
+                .getObjects().get(0);
 
-            if (wesCommandParser.wesMain.isVerbose()) {
-                out("hello");
+            // Print the WES URL and parsed credentials type
+            if (parsedCommand.isVerbose()) {
+                out("WES URL: " + wesRequestData.getUrl());
+                out("Credentials type: " + wesRequestData.getCredentialType());
             }
 
             // Depending on the desired WES request, parse input parameters from the command line

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -1127,12 +1127,9 @@ public abstract class AbstractEntryClient<T> {
      * @param clientWorkflowExecutionServiceApi The API client
      */
     private void wesCancel(WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi, final String runId, boolean verbose) {
-        out("Canceling WES workflow");
         try {
             RunId response = clientWorkflowExecutionServiceApi.cancelRun(runId);
-            if (verbose) {
-                out("Cancelled run with id: " + response.toString());
-            }
+            out("Cancelled run with id: " + response.toString());
         } catch (io.openapi.wes.client.ApiException e) {
             LOG.error("Error canceling WES run", e);
         }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -1225,7 +1225,8 @@ public abstract class AbstractEntryClient<T> {
             setWesRequestData(requestData);
             WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi = getWorkflowExecutionServiceApi();
 
-            // All Wes commands are parsed as subclasses of WesMain. W
+            // All Wes commands are parsed as subclasses of WesMain. We need to extract which object was created to parse with jCommander
+            // so we can get a global attribute.
             WesCommandParser.WesMain parsedCommand = (WesCommandParser.WesMain) wesCommandParser.jCommander.getCommands()
                 .get(wesCommandParser.jCommander.getParsedCommand())
                 .getObjects().get(0);

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -1117,7 +1117,7 @@ public abstract class AbstractEntryClient<T> {
             RunLog response = clientWorkflowExecutionServiceApi.getRunLog(workflowId);
             out(response.toString());
         } catch (io.openapi.wes.client.ApiException e) {
-            LOG.error("Error getting verbose WES run status", e);
+            LOG.error("Error getting WES run logs", e);
         }
     }
 

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
@@ -38,6 +38,7 @@ import io.dockstore.client.cli.Client;
 import io.dockstore.client.cli.SwaggerUtility;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.Registry;
+import io.openapi.wes.client.api.WorkflowExecutionServiceApi;
 import io.swagger.client.ApiException;
 import io.swagger.client.api.ContainersApi;
 import io.swagger.client.api.ContainertagsApi;
@@ -1136,13 +1137,14 @@ public class ToolClient extends AbstractEntryClient<DockstoreTool> {
 
     /**
      * Does nothing currently, as tools are not supported in WES
-     *
+     * @param clientWorkflowExecutionServiceApi The WES API client
      * @param entry The path to the desired entry (i.e. github.com/myrepo/myworfklow:version1
      * @param inlineWorkflow Indicates that the workflow files will be inlined directly into the WES HTTP request
      * @param paramsPath Path to the parameter JSON file
      * @param filePaths Paths to any other required files for the WES execution
      */
-    void wesLaunch(String entry, boolean inlineWorkflow, String paramsPath, List<String> filePaths) {
+    void wesLaunch(WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi, String entry, boolean inlineWorkflow, String paramsPath,
+        List<String> filePaths) {
         // Only supports workflows for the moment
         throw new UnsupportedOperationException("WES launch does not currently support tools. Please launch a workflow instead.");
     }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
@@ -1142,9 +1142,10 @@ public class ToolClient extends AbstractEntryClient<DockstoreTool> {
      * @param inlineWorkflow Indicates that the workflow files will be inlined directly into the WES HTTP request
      * @param paramsPath Path to the parameter JSON file
      * @param filePaths Paths to any other required files for the WES execution
+     * @param verbose
      */
     void wesLaunch(WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi, String entry, boolean inlineWorkflow, String paramsPath,
-        List<String> filePaths) {
+        List<String> filePaths, boolean verbose) {
         // Only supports workflows for the moment
         throw new UnsupportedOperationException("WES launch does not currently support tools. Please launch a workflow instead.");
     }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
@@ -12,6 +12,7 @@ public class WesCommandParser {
     public CommandLaunch commandLaunch;
     public CommandCancel commandCancel;
     public CommandStatus commandStatus;
+    public CommandRunLogs commandRunLogs;
     public CommandServiceInfo commandServiceInfo;
     public CommandRunList commandRunList;
     public JCommander jCommander;
@@ -21,6 +22,7 @@ public class WesCommandParser {
         this.commandLaunch = new CommandLaunch();
         this.commandCancel = new CommandCancel();
         this.commandStatus = new CommandStatus();
+        this.commandRunLogs = new CommandRunLogs();
         this.commandServiceInfo = new CommandServiceInfo();
         this.commandRunList = new CommandRunList();
 
@@ -35,6 +37,7 @@ public class WesCommandParser {
             .addCommand("launch", this.commandLaunch)
             .addCommand("cancel", this.commandCancel)
             .addCommand("status", this.commandStatus)
+            .addCommand("logs", this.commandRunLogs)
             .addCommand("service-info", this.commandServiceInfo)
             .addCommand("list", this.commandRunList)
             .build();
@@ -104,15 +107,20 @@ public class WesCommandParser {
     public static class CommandStatus extends WesMain {
         @Parameter(names = "--id", description = "The ID of the workflow to cancel", required = true)
         private String id;
-        @Parameter(names = "--verbose", description = "Flag indicating to print verbose logs", required = false)
-        private boolean verbose = false;
 
         public String getId() {
             return id;
         }
 
-        public boolean isVerbose() {
-            return verbose;
+    }
+
+    @Parameters(commandDescription = "Retrieve the status of a workflow")
+    public static class CommandRunLogs extends WesMain {
+        @Parameter(names = "--id", description = "The ID of the workflow to cancel", required = true)
+        private String id;
+
+        public String getId() {
+            return id;
         }
     }
 

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
@@ -49,8 +49,8 @@ public class WesCommandParser {
         private String wesUrl = null;
         @Parameter(names = "--help", description = "Prints help for launch command", help = true)
         private boolean help = false;
-        @Parameter(names = "--debug", description = "Sets the CLI to debug mode.", help = true)
-        private boolean debug = false;
+        @Parameter(names = "--verbose", description = "Sets the CLI to verbose mode.")
+        private boolean verbose = false;
 
         public String getWesUrl() {
             return wesUrl;
@@ -60,8 +60,8 @@ public class WesCommandParser {
             return help;
         }
 
-        public boolean debugMode() {
-            return debug;
+        public boolean isVerbose() {
+            return verbose;
         }
     }
 

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesCommandParser.java
@@ -46,6 +46,8 @@ public class WesCommandParser {
         private String wesUrl = null;
         @Parameter(names = "--help", description = "Prints help for launch command", help = true)
         private boolean help = false;
+        @Parameter(names = "--debug", description = "Sets the CLI to debug mode.", help = true)
+        private boolean debug = false;
 
         public String getWesUrl() {
             return wesUrl;
@@ -53,6 +55,10 @@ public class WesCommandParser {
 
         public boolean isHelp() {
             return help;
+        }
+
+        public boolean debugMode() {
+            return debug;
         }
     }
 

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesLauncher.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesLauncher.java
@@ -53,7 +53,7 @@ public final class WesLauncher {
      * @param workflowParamPath The path to a file to be used as an input JSON. (i.e. /path/to/file.json)
      * @param filePaths A list of paths to files to be attached to the request.
      */
-    public static void launchWesCommand(WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi, WorkflowClient workflowClient, String workflowEntry, boolean inlineWorkflow, String workflowParamPath, List<String> filePaths) {
+    public static void launchWesCommand(WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi, WorkflowClient workflowClient, String workflowEntry, boolean inlineWorkflow, String workflowParamPath, List<String> filePaths, boolean verbose) {
 
         // Get the workflow object associated with the provided entry path
         final Workflow workflow = getWorkflowForEntry(workflowClient, workflowEntry);
@@ -101,6 +101,11 @@ public final class WesLauncher {
         // The workflow version
         String workflowTypeVersion = createWorkflowTypeVersion(workflowType);
 
+        if (verbose) {
+            out("Primary descriptor URI: " + workflowUrl);
+            out("Number of file attachments: " + workflowAttachment.size());
+        }
+
         try {
             RunId response = clientWorkflowExecutionServiceApi.runWorkflow(
                     workflowParams,
@@ -113,8 +118,8 @@ public final class WesLauncher {
 
             String runID = response.getRunId();
 
-            // If debugging, print verbose messages and helper commands, otherwise just print the runId
-            if (clientWorkflowExecutionServiceApi.getApiClient().isDebugging()) {
+            // If verbose launches, print verbose messages and helper commands, otherwise just print the runId
+            if (verbose) {
                 out("Launched WES run with id: " + runID);
                 wesCommandSuggestions(runID);
             } else {

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesLauncher.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesLauncher.java
@@ -96,6 +96,10 @@ public final class WesLauncher {
             // Download all workflow files and place them into a temporary directory, then add them as attachments to the WES request
             final File unzippedWorkflowDir = provisionFilesLocally(workflowClient, workflowEntry, workflowType);
             workflowAttachment.addAll(fetchFilesFromLocalDirectory(unzippedWorkflowDir.getAbsolutePath()));
+
+            if (verbose) {
+                out("Workflow files provisioned to temporary directory: " + unzippedWorkflowDir.getAbsolutePath());
+            }
         }
 
         // The workflow version
@@ -191,7 +195,6 @@ public final class WesLauncher {
             throw new RuntimeException(ex);
         }
 
-        out("Successfully downloaded files for entry '" + workflowEntry + "'");
         return unzippedWorkflowDir;
     }
 

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesLauncher.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesLauncher.java
@@ -112,8 +112,15 @@ public final class WesLauncher {
                     workflowAttachment);
 
             String runID = response.getRunId();
-            out("Launched WES run with id: " + runID);
-            wesCommandSuggestions(runID);
+
+            // If debugging, print verbose messages and helper commands, otherwise just print the runId
+            if (clientWorkflowExecutionServiceApi.getApiClient().isDebugging()) {
+                out("Launched WES run with id: " + runID);
+                wesCommandSuggestions(runID);
+            } else {
+                out(runID);
+            }
+
         } catch (io.openapi.wes.client.ApiException e) {
             LOG.error("Error launching WES run", e);
         }
@@ -305,6 +312,6 @@ public final class WesLauncher {
     public static void wesCommandSuggestions(String runId) {
         out("To view the workflow run status, execute: ");
         out(MessageFormat.format("\tdockstore workflow wes status --id {0}", runId));
-        out(MessageFormat.format("\tdockstore workflow wes status --id {0} --verbose", runId));
+        out(MessageFormat.format("\tdockstore workflow wes logs --id {0}", runId));
     }
 }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesLauncher.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesLauncher.java
@@ -15,6 +15,7 @@ import io.dockstore.client.cli.SwaggerUtility;
 import io.dockstore.openapi.client.ApiClient;
 import io.dockstore.openapi.client.ApiException;
 import io.dockstore.openapi.client.model.WorkflowSubClass;
+import io.openapi.wes.client.api.WorkflowExecutionServiceApi;
 import io.openapi.wes.client.model.RunId;
 import io.swagger.client.model.ToolDescriptor;
 import io.swagger.client.model.Workflow;
@@ -52,7 +53,7 @@ public final class WesLauncher {
      * @param workflowParamPath The path to a file to be used as an input JSON. (i.e. /path/to/file.json)
      * @param filePaths A list of paths to files to be attached to the request.
      */
-    public static void launchWesCommand(WorkflowClient workflowClient, String workflowEntry, boolean inlineWorkflow, String workflowParamPath, List<String> filePaths) {
+    public static void launchWesCommand(WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi, WorkflowClient workflowClient, String workflowEntry, boolean inlineWorkflow, String workflowParamPath, List<String> filePaths) {
 
         // Get the workflow object associated with the provided entry path
         final Workflow workflow = getWorkflowForEntry(workflowClient, workflowEntry);
@@ -101,9 +102,7 @@ public final class WesLauncher {
         String workflowTypeVersion = createWorkflowTypeVersion(workflowType);
 
         try {
-            RunId response = workflowClient
-                .getWorkflowExecutionServiceApi()
-                .runWorkflow(
+            RunId response = clientWorkflowExecutionServiceApi.runWorkflow(
                     workflowParams,
                     workflowType,
                     workflowTypeVersion,

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -539,9 +539,10 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
      * @param inlineWorkflow Indicates that the workflow files will be inlined directly into the WES HTTP request
      * @param paramsPath Path to the parameter JSON file
      * @param filePaths Paths to any other required files for the WES execution
+     * @param verbose
      */
     void wesLaunch(WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi, String entry, boolean inlineWorkflow, String paramsPath,
-        List<String> filePaths) {
+        List<String> filePaths, boolean verbose) {
         WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, this, entry, inlineWorkflow, paramsPath, filePaths);
     }
 

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -40,6 +40,7 @@ import io.dockstore.client.cli.JCommanderUtility;
 import io.dockstore.client.cli.SwaggerUtility;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.SourceControl;
+import io.openapi.wes.client.api.WorkflowExecutionServiceApi;
 import io.swagger.client.ApiException;
 import io.swagger.client.api.UsersApi;
 import io.swagger.client.api.WorkflowsApi;
@@ -533,14 +534,15 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
 
     /**
      * Attempts to launch a workflow on a WES server
-     *
+     * @param clientWorkflowExecutionServiceApi The WES API client
      * @param entry The path to the desired entry (i.e. github.com/myrepo/myworfklow:version1
      * @param inlineWorkflow Indicates that the workflow files will be inlined directly into the WES HTTP request
      * @param paramsPath Path to the parameter JSON file
      * @param filePaths Paths to any other required files for the WES execution
      */
-    void wesLaunch(String entry, boolean inlineWorkflow, String paramsPath, List<String> filePaths) {
-        WesLauncher.launchWesCommand(this, entry, inlineWorkflow, paramsPath, filePaths);
+    void wesLaunch(WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi, String entry, boolean inlineWorkflow, String paramsPath,
+        List<String> filePaths) {
+        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, this, entry, inlineWorkflow, paramsPath, filePaths);
     }
 
     @Override

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -539,11 +539,11 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
      * @param inlineWorkflow Indicates that the workflow files will be inlined directly into the WES HTTP request
      * @param paramsPath Path to the parameter JSON file
      * @param filePaths Paths to any other required files for the WES execution
-     * @param verbose
+     * @param verbose Launching with verbose logs
      */
     void wesLaunch(WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi, String entry, boolean inlineWorkflow, String paramsPath,
         List<String> filePaths, boolean verbose) {
-        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, this, entry, inlineWorkflow, paramsPath, filePaths);
+        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, this, entry, inlineWorkflow, paramsPath, filePaths, verbose);
     }
 
     @Override

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/AbstractEntryClientTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/AbstractEntryClientTestIT.java
@@ -27,9 +27,9 @@ public class AbstractEntryClientTestIT {
     @Rule
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog();
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
     @Rule
     public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
@@ -39,7 +39,7 @@ public class AbstractEntryClientTestIT {
     @Test
     public void testWESHelpMessages() {
         final String clientConfig = ResourceHelpers.resourceFilePath("clientConfig");
-        final String[] commandNames = {"", "launch", "status", "cancel", "service-info"};
+        final String[] commandNames = {"", "launch", "status", "cancel", "service-info", "logs", "list"};
 
         // has config file
         for (String command : commandNames) {

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
@@ -205,8 +205,7 @@ public class WesCommandParserTest {
         final String[] args = {
             "status",
             "--id",
-            "123456",
-            "--verbose"
+            "123456"
         };
 
         WesCommandParser wesCommandParser = new WesCommandParser();
@@ -215,7 +214,6 @@ public class WesCommandParserTest {
 
         assertEquals("Parsed command should be 'status'", "status", parser.getParsedCommand());
         assertEquals("The parsed entry should be '123456'", "123456", wesCommandParser.commandStatus.getId());
-        assertTrue("verbose flag should be set", wesCommandParser.commandStatus.isVerbose());
     }
 
     @Test

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WesCommandParserTest.java
@@ -301,4 +301,33 @@ public class WesCommandParserTest {
         assertEquals("Page token should be set to 'banana'", "banana", wesCommandParser.commandRunList.getPageToken());
 
     }
+
+    @Test
+    public void testCommandRunLogsHelp() {
+        final String[] args = {
+            "logs",
+            "--help"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        parser.parse(args);
+        assertTrue("Help should be set", wesCommandParser.commandRunLogs.isHelp());
+    }
+
+    @Test
+    public void testCommandRunlogs1() {
+        final String[] args = {
+            "logs",
+            "--id",
+            "123456"
+        };
+
+        WesCommandParser wesCommandParser = new WesCommandParser();
+        JCommander parser = wesCommandParser.jCommander;
+        parser.parse(args);
+
+        assertEquals("Parsed command should be 'logs'", "logs", parser.getParsedCommand());
+        assertEquals("The parsed entry should be '123456'", "123456", wesCommandParser.commandRunLogs.getId());
+    }
 }

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WesLauncherIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WesLauncherIT.java
@@ -128,7 +128,7 @@ public class WesLauncherIT {
         String workflowEntry = "my/entry/path";
         WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi = mockWesApi();
 
-        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, null, null);
+        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, null, null, false);
         assertTrue("The runId should be printed out", systemOutRule.getLog().contains(RUN_ID));
     }
 
@@ -140,7 +140,7 @@ public class WesLauncherIT {
         List<String> attachments = new ArrayList<>();
         WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi = mockWesApi();
 
-        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, workflowParamPath, attachments);
+        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, workflowParamPath, attachments, false);
         assertTrue("The runId should be printed out", systemOutRule.getLog().contains(RUN_ID));
     }
 
@@ -154,7 +154,7 @@ public class WesLauncherIT {
 
         // Expect an error to be thrown when a file cant be found
         systemExit.expectSystemExit();
-        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, workflowParamPath, attachments);
+        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, workflowParamPath, attachments, false);
         assertTrue("The file doesn't exist, so an error should be thrown",
             systemErrRule.getLog().contains("Unable to locate file: this/file/doesnt/exist"));
     }
@@ -171,7 +171,7 @@ public class WesLauncherIT {
         WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi = mockWesApi();
 
         // Expect an error to be thrown when a file cant be found
-        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, workflowParamPath, attachments);
+        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, workflowParamPath, attachments, false);
         assertTrue("The runId should be printed out", systemOutRule.getLog().contains(RUN_ID));
 
     }
@@ -187,7 +187,7 @@ public class WesLauncherIT {
 
         // Expect an error to be thrown when a file cant be found
         systemExit.expectSystemExit();
-        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, workflowParamPath, attachments);
+        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, workflowParamPath, attachments, false);
         assertTrue("The file doesn't exist, so an error should be thrown",
             systemErrRule.getLog().contains("Unable to locate file: this/file/doesnt/exist"));
     }
@@ -205,7 +205,7 @@ public class WesLauncherIT {
 
         // Expect an error to be thrown when a file cant be found
         systemExit.expectSystemExit();
-        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, workflowParamPath, attachments);
+        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, workflowParamPath, attachments, false);
         assertTrue("The file doesn't exist, so an error should be thrown",
             systemErrRule.getLog().contains("Unable to locate file: uh/oh/this/is/a/typo"));
     }
@@ -218,7 +218,7 @@ public class WesLauncherIT {
         WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi = mockWesApi();
 
         // Directories should be ignored, no error should be thrown
-        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, workflowParamPath, null);
+        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, workflowParamPath, null, false);
     }
 
     @Test

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WesLauncherIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WesLauncherIT.java
@@ -57,7 +57,7 @@ public class WesLauncherIT {
         return workflow;
     }
 
-    public WorkflowClient mockWorkflowClient(String configPath) throws ApiException {
+    public WorkflowClient mockWorkflowClient(String configPath) {
 
         // Create the CLI client
         Client client = new Client();
@@ -71,11 +71,30 @@ public class WesLauncherIT {
         // Mock the workflows API, and return a prebuilt workflow
         WorkflowsApi workflowApi = mock(WorkflowsApi.class);
         WorkflowClient workflowClient = mock(WorkflowClient.class);
-        WorkflowExecutionServiceApi fakeApi = mock(WorkflowExecutionServiceApi.class);
 
         // Set request credentials object
         WesRequestData wrd = new WesRequestData("myUrl", "myBearerToken");
         workflowClient.setWesRequestData(wrd);
+
+        // WorkflowsApi Function mocks
+        when(workflowApi.getPublishedWorkflowByPath(
+            any(String.class),
+            any(String.class),
+            ArgumentMatchers.isNull(),
+            any(String.class)
+        )).thenReturn(fakeWorkflow);
+
+        // WorkflowClient function mocks
+        when(workflowClient.getClient()).thenReturn(client);
+        when(workflowClient.getVersionID(any(String.class))).thenReturn(fakeWorkflow.getDefaultVersion());
+        when(workflowClient.getTrsId(any(String.class))).thenReturn("#workflow/" + WORKFLOW_PATH);
+        when(workflowClient.getWorkflowsApi()).thenReturn(workflowApi);
+
+        return workflowClient;
+    }
+
+    public WorkflowExecutionServiceApi mockWesApi() throws ApiException {
+        WorkflowExecutionServiceApi fakeApi = mock(WorkflowExecutionServiceApi.class);
 
         // Mock requests to the GA4GH WES API, returning a fake run ID
         RunId runId = new RunId();
@@ -100,30 +119,16 @@ public class WesLauncherIT {
             any(List.class)
         )).thenReturn(runId);
 
-        // WorkflowsApi Function mocks
-        when(workflowApi.getPublishedWorkflowByPath(
-            any(String.class),
-            any(String.class),
-            ArgumentMatchers.isNull(),
-            any(String.class)
-        )).thenReturn(fakeWorkflow);
-
-        // WorkflowClient function mocks
-        when(workflowClient.getClient()).thenReturn(client);
-        when(workflowClient.getVersionID(any(String.class))).thenReturn(fakeWorkflow.getDefaultVersion());
-        when(workflowClient.getTrsId(any(String.class))).thenReturn("#workflow/" + WORKFLOW_PATH);
-        when(workflowClient.getWorkflowsApi()).thenReturn(workflowApi);
-        when(workflowClient.getWorkflowExecutionServiceApi()).thenReturn(fakeApi);
-
-        return workflowClient;
+        return fakeApi;
     }
 
     @Test
     public void testLaunchWithNoFiles() throws ApiException {
         WorkflowClient workflowClient = mockWorkflowClient("configNoContent");
         String workflowEntry = "my/entry/path";
+        WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi = mockWesApi();
 
-        WesLauncher.launchWesCommand(workflowClient, workflowEntry, false, null, null);
+        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, null, null);
         assertTrue("The runId should be printed out", systemOutRule.getLog().contains(RUN_ID));
     }
 
@@ -133,8 +138,9 @@ public class WesLauncherIT {
         String workflowEntry = "my/entry/path";
         String workflowParamPath = ResourceHelpers.resourceFilePath("helloSpaces.json");
         List<String> attachments = new ArrayList<>();
+        WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi = mockWesApi();
 
-        WesLauncher.launchWesCommand(workflowClient, workflowEntry, false, workflowParamPath, attachments);
+        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, workflowParamPath, attachments);
         assertTrue("The runId should be printed out", systemOutRule.getLog().contains(RUN_ID));
     }
 
@@ -144,10 +150,11 @@ public class WesLauncherIT {
         String workflowEntry = "my/entry/path";
         String workflowParamPath = "this/file/doesnt/exist";
         List<String> attachments = new ArrayList<>();
+        WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi = mockWesApi();
 
         // Expect an error to be thrown when a file cant be found
         systemExit.expectSystemExit();
-        WesLauncher.launchWesCommand(workflowClient, workflowEntry, false, workflowParamPath, attachments);
+        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, workflowParamPath, attachments);
         assertTrue("The file doesn't exist, so an error should be thrown",
             systemErrRule.getLog().contains("Unable to locate file: this/file/doesnt/exist"));
     }
@@ -161,9 +168,10 @@ public class WesLauncherIT {
         attachments.add(ResourceHelpers.resourceFilePath("helloSpaces.json"));
         attachments.add(ResourceHelpers.resourceFilePath("helloSpaces.wdl"));
         attachments.add(ResourceHelpers.resourceFilePath("idNonWord.cwl"));
+        WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi = mockWesApi();
 
         // Expect an error to be thrown when a file cant be found
-        WesLauncher.launchWesCommand(workflowClient, workflowEntry, false, workflowParamPath, attachments);
+        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, workflowParamPath, attachments);
         assertTrue("The runId should be printed out", systemOutRule.getLog().contains(RUN_ID));
 
     }
@@ -175,10 +183,11 @@ public class WesLauncherIT {
         String workflowParamPath = ResourceHelpers.resourceFilePath("helloSpaces.json");
         List<String> attachments = new ArrayList<>();
         attachments.add("this/file/doesnt/exist");
+        WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi = mockWesApi();
 
         // Expect an error to be thrown when a file cant be found
         systemExit.expectSystemExit();
-        WesLauncher.launchWesCommand(workflowClient, workflowEntry, false, workflowParamPath, attachments);
+        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, workflowParamPath, attachments);
         assertTrue("The file doesn't exist, so an error should be thrown",
             systemErrRule.getLog().contains("Unable to locate file: this/file/doesnt/exist"));
     }
@@ -192,10 +201,11 @@ public class WesLauncherIT {
         attachments.add(ResourceHelpers.resourceFilePath("helloSpaces.json"));
         attachments.add("uh/oh/this/is/a/typo");
         attachments.add(ResourceHelpers.resourceFilePath("helloSpaces.wdl"));
+        WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi = mockWesApi();
 
         // Expect an error to be thrown when a file cant be found
         systemExit.expectSystemExit();
-        WesLauncher.launchWesCommand(workflowClient, workflowEntry, false, workflowParamPath, attachments);
+        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, workflowParamPath, attachments);
         assertTrue("The file doesn't exist, so an error should be thrown",
             systemErrRule.getLog().contains("Unable to locate file: uh/oh/this/is/a/typo"));
     }
@@ -205,9 +215,10 @@ public class WesLauncherIT {
         WorkflowClient workflowClient = mockWorkflowClient("configNoContent");
         String workflowEntry = "my/entry/path";
         String workflowParamPath = ResourceHelpers.resourceFilePath("");
+        WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi = mockWesApi();
 
         // Directories should be ignored, no error should be thrown
-        WesLauncher.launchWesCommand(workflowClient, workflowEntry, false, workflowParamPath, null);
+        WesLauncher.launchWesCommand(clientWorkflowExecutionServiceApi, workflowClient, workflowEntry, false, workflowParamPath, null);
     }
 
     @Test

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WesLauncherTest.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WesLauncherTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class WesLauncherIT {
+public class WesLauncherTest {
 
     public static final String RUN_ID = "123456-098765-123123-04983782";
     public static final String WORKFLOW_PATH = "github.com/org/repo";
@@ -36,9 +36,9 @@ public class WesLauncherIT {
     @Rule
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog();
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
 
     public Workflow buildFakeWorkflow() {
         Workflow workflow = new Workflow();


### PR DESCRIPTION
This PR makes two changes, which effectively addresses two separate tickets:
1. Instead of having the `runLogs` WES endpoint hidden under `dockstore workflow wes status --verbose`, it was switched into its own switch, `dockstore workflow wes logs`. This addresses https://github.com/dockstore/dockstore/issues/4571
2. The reason the above change was made in this PR is to free up the `--verbose` flag for all WES requests, as `--debug` is already used by the base client. Now, when adding `--verbose` to a WES command, we get some additional printed information: https://github.com/dockstore/dockstore/issues/4709

For example, the verbose outputs will look like:
```
WES URL: https://r558d7505b.execute-api.us-west-2.amazonaws.com/prod/ga4gh/wes/v1
Credentials type: AWS_TEMPORARY_CREDENTIALS
Primary descriptor URI: https://dockstore.org/api/ga4gh/trs/v2/tools/%23workflow%2Fgithub.com%2Fhuman-pangenomics%2Fhpp_production_workflows%2FfastqReadCounts/versions/master/PLAIN_WDL/descriptor/%2FQC%2Fwdl%2Ftasks%2FfastqReadCounts.wdl
Number of file attachments: 1
Launched WES run with id: 4f10f005-f635-4f02-b1bd-7d6a3ada9469
To view the workflow run status, execute: 
	dockstore workflow wes status --id 4f10f005-f635-4f02-b1bd-7d6a3ada9469
	dockstore workflow wes logs --id 4f10f005-f635-4f02-b1bd-7d6a3ada9469
```
The non-verbose outputs (by default, when the `--verbose` flag isn't used)
```
4f10f005-f635-4f02-b1bd-7d6a3ada9469
```

Frankly, I'm not too happy with how these messages are logged, using `out()`s inside a bunch of conditionals feels 'odd'. There doesn't seem to be a reasonable place to attach a WES-only logger, but perhaps I'm missing something obvious...

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [X] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
