### PR TITLE
WES response JSON printing

### DIFF
--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WesToilIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WesToilIT.java
@@ -18,9 +18,9 @@ public class WesToilIT {
     public static final int WAIT_ITER_TIME_MILLI = 10000; // The time between each check of a workflow run status
 
     public static final String RUN_ID_PATTERN_PREFIX = "Launched WES run with id:";
-    public static final String COMPLETED_STATE = "state: COMPLETE";
-    public static final String EXECUTOR_ERROR_STATE = "state: EXECUTOR_ERROR";
-    public static final String CANCELED_STATE = "state: CANCELED";
+    public static final String COMPLETED_STATE = "\"state\" : \"COMPLETE\"";
+    public static final String EXECUTOR_ERROR_STATE = "\"state\" : \"EXECUTOR_ERROR\"";
+    public static final String CANCELED_STATE = "\"state\" : \"CANCELED\"";
 
     @Rule
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();

--- a/dockstore-client/generated/src/main/resources/pom.xml
+++ b/dockstore-client/generated/src/main/resources/pom.xml
@@ -160,6 +160,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.12.3</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>io.cwl</groupId>
       <artifactId>cwlavro-tools</artifactId>
       <version>2.0.4.7</version>

--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -157,6 +157,10 @@
             <artifactId>jackson-jaxrs-base</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.cwl</groupId>
             <artifactId>cwlavro-tools</artifactId>
         </dependency>

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -43,6 +43,8 @@ import com.amazonaws.auth.profile.ProfilesConfigFile;
 import com.amazonaws.regions.AwsProfileRegionProvider;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InfoCmd;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
@@ -1101,9 +1103,12 @@ public abstract class AbstractEntryClient<T> {
     private void wesStatus(WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi, final String workflowId) {
         try {
             RunStatus response = clientWorkflowExecutionServiceApi.getRunStatus(workflowId);
-            out(response.toString());
+            ObjectMapper mapper = new ObjectMapper();
+            out(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(response));
         } catch (io.openapi.wes.client.ApiException e) {
             LOG.error("Error getting brief WES run status", e);
+        } catch (JsonProcessingException e) {
+            LOG.error("Unable to convert WES response object to JSON", e);
         }
     }
 
@@ -1115,9 +1120,12 @@ public abstract class AbstractEntryClient<T> {
     private void wesRunLogs(WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi, final String workflowId) {
         try {
             RunLog response = clientWorkflowExecutionServiceApi.getRunLog(workflowId);
-            out(response.toString());
+            ObjectMapper mapper = new ObjectMapper();
+            out(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(response));
         } catch (io.openapi.wes.client.ApiException e) {
             LOG.error("Error getting WES run logs", e);
+        } catch (JsonProcessingException e) {
+            LOG.error("Unable to convert WES response object to JSON", e);
         }
     }
 
@@ -1142,9 +1150,12 @@ public abstract class AbstractEntryClient<T> {
     private void wesServiceInfo(WorkflowExecutionServiceApi clientWorkflowExecutionServiceApi) {
         try {
             ServiceInfo response = clientWorkflowExecutionServiceApi.getServiceInfo();
-            out(response.toString());
+            ObjectMapper mapper = new ObjectMapper();
+            out(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(response));
         } catch (io.openapi.wes.client.ApiException e) {
             LOG.error("Error getting WES server info", e);
+        } catch (JsonProcessingException e) {
+            LOG.error("Unable to convert WES response object to JSON", e);
         }
     }
 
@@ -1160,9 +1171,12 @@ public abstract class AbstractEntryClient<T> {
                 out(MessageFormat.format("Requesting latest {0} runs", pageSize));
             }
             RunListResponse response = clientWorkflowExecutionServiceApi.listRuns((long)pageSize, pageToken);
-            out(response.toString());
+            ObjectMapper mapper = new ObjectMapper();
+            out(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(response));
         } catch (io.openapi.wes.client.ApiException e) {
             LOG.error("Error getting WES Run List", e);
+        } catch (JsonProcessingException e) {
+            LOG.error("Unable to convert WES response object to JSON", e);
         }
     }
 


### PR DESCRIPTION
This PR changes the print formatting of WES responses. We are now printing the responses as pure JSON (rather than Stringified Objects). So the user will see:
```
{
  "workflow_type_versions" : {
    "WDL" : {
      "workflow_type_version" : [ "1.0", "draft-2" ]
    }
  },
  "supported_wes_versions" : [ "1.0.0" ],
  "supported_filesystem_protocols" : null,
  "workflow_engine_versions" : null,
  "default_workflow_engine_parameters" : null,
  "system_state_counts" : null,
  "auth_instructions_url" : null,
  "contact_info_url" : null,
  "tags" : {
    "cromwell_service_health" : "True",
    "description" : "WES adapter for Cromwell workflow engine service.",
    "name" : "remote_cromwell_wes_adapter",
    "updated_at" : "2022-02-23T17:37:54.672500Z"
  }
}
```

instead of:
```
class ServiceInfo {
    workflowTypeVersions: {WDL=class WorkflowTypeVersion {
        workflowTypeVersion: [1.0, draft-2]
    }}
    supportedWesVersions: [1.0.0]
    supportedFilesystemProtocols: null
    workflowEngineVersions: null
    defaultWorkflowEngineParameters: null
    systemStateCounts: null
    authInstructionsUrl: null
    contactInfoUrl: null
    tags: {cromwell_service_health=True, description=WES adapter for Cromwell workflow engine service., name=remote_cromwell_wes_adapter, updated_at=2022-02-23T17:38:53.388191Z}
}
```

The two WES POSTs (RunWorkflow and CancelRun) do not use the JSON printing, as the response Object in JSON looks like: `{"runId": "123-456-789"}`, so I left it as just the Run ID `123-456-789`.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [X] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
