### PR TITLE
Feature/dock 2057/improve launch failure message

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/ArgumentUtility.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/ArgumentUtility.java
@@ -91,6 +91,12 @@ public final class ArgumentUtility {
         System.exit(exitCode);
     }
 
+    public static void conditionalErrorMessage(boolean isError, String message, int exitCode) {
+        if (isError) {
+            errorMessage(message, exitCode);
+        }
+    }
+
     /**
      * @param bool primitive
      * @return the String "Yes" or "No"

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -506,7 +506,8 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
                                 errorMessage("Workflow type not supported for launch: " + path, ENTRY_NOT_FOUND);
                                 break;
                             }
-                        } catch (IOException | ApiException | UnsupportedOperationException e) {
+                        } catch (Exception e) {
+                            // in addition to its checked exceptions, languageClientInterface.launch() can throw a variety of RuntimeExceptions, handle them all here
                             exceptionMessage(e, "Could not launch entry", IO_ERROR);
                         }
                         

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -490,34 +490,29 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
                         LanguageClientInterface languageClientInterface = convertCLIStringToEnum(descriptor);
                         DescriptorLanguage language = DescriptorLanguage.convertShortStringToEnum(descriptor);
 
-                        switch (language) {
-                        case CWL:
-                            if ((yamlRun != null) == (jsonRun != null)) {
-                                errorMessage("One of  --json, --yaml, and --tsv is required", CLIENT_ERROR);
-                            } else {
-                                try {
-                                    languageClientInterface.launch(entry, false, yamlRun, jsonRun, null, uuid);
-                                } catch (Exception e) {
-                                    exceptionMessage(e, "Could not launch entry", IO_ERROR);
+                        try {
+                            switch (language) {
+                            case CWL:
+                                if ((yamlRun != null) == (jsonRun != null)) {
+                                    errorMessage("One of  --json, --yaml, and --tsv is required", CLIENT_ERROR);
                                 }
-                            }
-                            break;
-                        case WDL:
-                        case NEXTFLOW:
-                            if (jsonRun == null) {
-                                errorMessage("dockstore: missing required flag --json", Client.CLIENT_ERROR);
-                            } else {
-                                try {
-                                    languageClientInterface.launch(entry, false, null, jsonRun, wdlOutputTarget, uuid);
-                                } catch (Exception e) {
-                                    exceptionMessage(e, "Could not launch entry", IO_ERROR);
+                                languageClientInterface.launch(entry, false, yamlRun, jsonRun, null, uuid);
+                                break;
+                            case WDL:
+                            case NEXTFLOW:
+                                if (jsonRun == null) {
+                                    errorMessage("dockstore: missing required flag --json", Client.CLIENT_ERROR);
                                 }
+                                languageClientInterface.launch(entry, false, null, jsonRun, wdlOutputTarget, uuid);
+                                break;
+                            default:
+                                errorMessage("Workflow type not supported for launch: " + path, ENTRY_NOT_FOUND);
+                                break;
                             }
-                            break;
-                        default:
-                            errorMessage("Workflow type not supported for launch: " + path, ENTRY_NOT_FOUND);
-                            break;
+                        } catch (Exception e) {
+                            exceptionMessage(e, "Could not launch entry", IO_ERROR);
                         }
+                        
                     } catch (ApiException e) {
                         exceptionMessage(e, "Could not get workflow: " + path, ENTRY_NOT_FOUND);
                     }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -497,20 +497,20 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
                             } else {
                                 try {
                                     languageClientInterface.launch(entry, false, yamlRun, jsonRun, null, uuid);
-                                } catch (IOException e) {
-                                    errorMessage("Could not launch entry", IO_ERROR);
+                                } catch (Exception e) {
+                                    exceptionMessage(e, "Could not launch entry", IO_ERROR);
                                 }
                             }
                             break;
                         case WDL:
                         case NEXTFLOW:
                             if (jsonRun == null) {
-                                errorMessage("dockstore: missing required flag " + "--json", Client.CLIENT_ERROR);
+                                errorMessage("dockstore: missing required flag --json", Client.CLIENT_ERROR);
                             } else {
                                 try {
                                     languageClientInterface.launch(entry, false, null, jsonRun, wdlOutputTarget, uuid);
                                 } catch (Exception e) {
-                                    errorMessage("Could not launch entry", IO_ERROR);
+                                    exceptionMessage(e, "Could not launch entry", IO_ERROR);
                                 }
                             }
                             break;
@@ -519,7 +519,7 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
                             break;
                         }
                     } catch (ApiException e) {
-                        errorMessage("Could not get workflow: " + path, ENTRY_NOT_FOUND);
+                        exceptionMessage(e, "Could not get workflow: " + path, ENTRY_NOT_FOUND);
                     }
                 } else {
                     this.isLocalEntry = true;

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -499,14 +499,14 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
                                 break;
                             case WDL:
                             case NEXTFLOW:
-                                conditionalErrorMessage(jsonRun == null, "dockstore: missing required flag --json", Client.CLIENT_ERROR);
+                                conditionalErrorMessage(jsonRun == null, "dockstore: missing required flag --json", CLIENT_ERROR);
                                 languageClientInterface.launch(entry, false, null, jsonRun, wdlOutputTarget, uuid);
                                 break;
                             default:
                                 errorMessage("Workflow type not supported for launch: " + path, ENTRY_NOT_FOUND);
                                 break;
                             }
-                        } catch (Exception e) {
+                        } catch (IOException | ApiException | UnsupportedOperationException e) {
                             exceptionMessage(e, "Could not launch entry", IO_ERROR);
                         }
                         

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -66,6 +66,7 @@ import static io.dockstore.client.cli.ArgumentUtility.GIT_HEADER;
 import static io.dockstore.client.cli.ArgumentUtility.NAME_HEADER;
 import static io.dockstore.client.cli.ArgumentUtility.boolWord;
 import static io.dockstore.client.cli.ArgumentUtility.columnWidthsWorkflow;
+import static io.dockstore.client.cli.ArgumentUtility.conditionalErrorMessage;
 import static io.dockstore.client.cli.ArgumentUtility.containsHelpRequest;
 import static io.dockstore.client.cli.ArgumentUtility.err;
 import static io.dockstore.client.cli.ArgumentUtility.errorMessage;
@@ -493,16 +494,12 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
                         try {
                             switch (language) {
                             case CWL:
-                                if ((yamlRun != null) == (jsonRun != null)) {
-                                    errorMessage("One of  --json, --yaml, and --tsv is required", CLIENT_ERROR);
-                                }
+                                conditionalErrorMessage((yamlRun != null) == (jsonRun != null), "One of  --json, --yaml, and --tsv is required", CLIENT_ERROR);
                                 languageClientInterface.launch(entry, false, yamlRun, jsonRun, null, uuid);
                                 break;
                             case WDL:
                             case NEXTFLOW:
-                                if (jsonRun == null) {
-                                    errorMessage("dockstore: missing required flag --json", Client.CLIENT_ERROR);
-                                }
+                                conditionalErrorMessage(jsonRun == null, "dockstore: missing required flag --json", Client.CLIENT_ERROR);
                                 languageClientInterface.launch(entry, false, null, jsonRun, wdlOutputTarget, uuid);
                                 break;
                             default:


### PR DESCRIPTION
This PR changes the dockstore CLI to print information about the exception thrown upon a launch failure (the type of exception, message [if present], and a stacktrace), in addition to the error message.  It also includes a cleanup of the adjacent launch code. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2057
dockstore/dockstore#4713

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
