### PR TITLE
make encrypt/scripts use sha256 digest

### DIFF
--- a/encrypt.sh
+++ b/encrypt.sh
@@ -12,7 +12,7 @@ set -o xtrace
 
 tar cvf secrets.tar dockstore-cli-integration-testing/src/test/resources/dstesting_pcks8.pem dockstore-cli-integration-testing/src/test/resources/config_file.txt dockstore-cli-integration-testing/src/test/resources/config_file2.txt dockstore-webservice/src/main/resources/migrations.test.confidential2.xml dockstore-cli-integration-testing/src/test/resources/dockstoreTest.yml dockstore-webservice/src/main/resources/migrations.test.confidential1.xml dockstore-webservice/src/main/resources/migrations.test.confidential1_1.5.0.xml dockstore-webservice/src/main/resources/migrations.test.confidential2_1.5.0.xml
 
-openssl aes-256-cbc -e -in secrets.tar -out circle_ci_test_data.zip.enc -k "$CIRCLE_CI_KEY_2" -iv "$CIRCLE_CI_IV_2"
+openssl aes-256-cbc -md sha256 -e -in secrets.tar -out circle_ci_test_data.zip.enc -k "$CIRCLE_CI_KEY_2" -iv "$CIRCLE_CI_IV_2"
 
 rm secrets.tar
 

--- a/scripts/decrypt.sh
+++ b/scripts/decrypt.sh
@@ -11,7 +11,7 @@ set -o xtrace
 : "$CIRCLE_CI_KEY_2"
 : "$CIRCLE_CI_IV_2"
 
-openssl aes-256-cbc -d -in circle_ci_test_data.zip.enc -k "$CIRCLE_CI_KEY_2" -iv "$CIRCLE_CI_IV_2" -out secrets.tar
+openssl aes-256-cbc -md sha256 -d -in circle_ci_test_data.zip.enc -k "$CIRCLE_CI_KEY_2" -iv "$CIRCLE_CI_IV_2" -out secrets.tar
 tar xvf secrets.tar
 # Create the directory where the .pem file will be placed for continuous integration
 # If you would like to change this path (might be a good idea since we no longer use


### PR DESCRIPTION
Add a flag to force the encrypt/decrypt scripts to use the SHA-256 message digest.  Without said flag, some [older?] openssl implementations default to a different digest.

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
