### PR TITLE
flush test output

### DIFF
--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
@@ -22,6 +22,8 @@ import java.util.List;
 import io.dockstore.client.cli.nested.ToolClient;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dockstore.common.Registry;
 import io.dockstore.common.SlowTest;
 import io.dockstore.common.SourceControl;
@@ -58,10 +60,10 @@ public class BasicIT extends BaseIT {
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
 
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog().muteForSuccessfulTests();
 
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
 
     @Before
     @Override

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import com.google.common.collect.Lists;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dockstore.common.Registry;
 import io.dockstore.common.TestUtility;
 import io.dockstore.common.ToilCompatibleTest;
@@ -49,10 +51,10 @@ public class ClientIT extends BaseIT {
 
     private static final String FIRST_TOOL = ResourceHelpers.resourceFilePath("dockstore-tool-helloworld.cwl");
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog().muteForSuccessfulTests();
 
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
 
     @Rule
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/CromwellIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/CromwellIT.java
@@ -31,6 +31,8 @@ import io.dockstore.client.cli.nested.LanguageClientInterface;
 import io.dockstore.client.cli.nested.ToolClient;
 import io.dockstore.common.ConfidentialTest;
 import io.dockstore.common.DescriptorLanguage;
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dockstore.common.ToolTest;
 import io.dockstore.common.WDLFileProvisioning;
 import io.dockstore.common.WdlBridge;
@@ -55,10 +57,10 @@ import wdl.draft3.parser.WdlParser;
 public class CromwellIT {
 
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog().muteForSuccessfulTests();
 
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
 
     @Rule
     public final ExpectedSystemExit exit = ExpectedSystemExit.none();

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -26,6 +26,8 @@ import java.util.zip.ZipFile;
 import io.dockstore.client.cli.nested.ToolClient;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dockstore.common.Registry;
 import io.dockstore.common.ToilCompatibleTest;
 import io.dockstore.common.ToolTest;
@@ -59,10 +61,10 @@ import static org.junit.Assert.assertTrue;
 public class GeneralIT extends BaseIT {
 
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog().muteForSuccessfulTests();
 
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
 
     @Rule
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -21,6 +21,8 @@ import java.util.List;
 import com.google.common.collect.Lists;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dockstore.common.SlowTest;
 import io.dockstore.common.SourceControl;
 import io.dockstore.common.ToilCompatibleTest;
@@ -61,10 +63,10 @@ public class GeneralWorkflowIT extends BaseIT {
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
 
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog().muteForSuccessfulTests();
 
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
 
     @Before
     @Override

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GitHubAppToolIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GitHubAppToolIT.java
@@ -1,6 +1,8 @@
 package io.dockstore.client.cli;
 
 import io.dockstore.common.CommonTestUtilities;
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dockstore.openapi.client.model.WorkflowSubClass;
 import io.dropwizard.testing.ResourceHelpers;
 import io.openapi.model.DescriptorType;
@@ -36,10 +38,10 @@ public class GitHubAppToolIT extends BaseIT {
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
 
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog().muteForSuccessfulTests();
 
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
 
 
     @Before

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/MockedIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/MockedIT.java
@@ -23,6 +23,8 @@ import java.nio.charset.StandardCharsets;
 import io.dockstore.client.cli.nested.ToolClient;
 import io.dockstore.common.ConfidentialTest;
 import io.dockstore.common.DescriptorLanguage;
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dockstore.common.TestUtility;
 import io.dockstore.common.ToolTest;
 import io.dropwizard.testing.ResourceHelpers;
@@ -69,10 +71,10 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 public class MockedIT {
 
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog().muteForSuccessfulTests();
 
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
 
     @Rule
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/NotificationsIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/NotificationsIT.java
@@ -18,6 +18,8 @@ package io.dockstore.client.cli;
 import java.io.IOException;
 
 import io.dockstore.common.ConfidentialTest;
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dockstore.common.TestUtility;
 import io.dockstore.common.ToolTest;
 import io.dropwizard.testing.ResourceHelpers;
@@ -44,9 +46,9 @@ public class NotificationsIT extends BaseIT {
     private static final String SENDING_NOTIFICATION = "Sending notifications message.";
     private static final String GENERATING_UUID = "The UUID generated for this specific execution is ";
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog().muteForSuccessfulTests();
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
     @Rule
     public final ExpectedSystemExit exit = ExpectedSystemExit.none();
 

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/SingularityIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/SingularityIT.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 
 import io.dockstore.client.cli.nested.SingularityTest;
 import io.dockstore.common.CommonTestUtilities;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dockstore.common.SourceControl;
 import io.dropwizard.testing.ResourceHelpers;
 import io.swagger.client.ApiClient;
@@ -30,7 +31,7 @@ public class SingularityIT extends BaseIT {
     private static final String SINGULARITY_CONFIG_TEMPLATE = ResourceHelpers.resourceFilePath("config_for_singularity");
 
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog();
 
     @Before
     @Override

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/StarIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/StarIT.java
@@ -1,6 +1,8 @@
 package io.dockstore.client.cli;
 
 import io.dockstore.common.CommonTestUtilities;
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dockstore.common.SourceControl;
 import io.dropwizard.testing.ResourceHelpers;
 import org.junit.Assert;
@@ -20,10 +22,10 @@ public class StarIT extends BaseIT {
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
 
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog();
 
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
 
     @Before
     @Override

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WDLWorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WDLWorkflowIT.java
@@ -25,6 +25,8 @@ import java.util.List;
 
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dockstore.common.SourceControl;
 import io.dockstore.common.WorkflowTest;
 import io.dropwizard.testing.ResourceHelpers;
@@ -66,10 +68,10 @@ public class WDLWorkflowIT extends BaseIT {
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
 
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog().muteForSuccessfulTests();
 
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WesToilIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WesToilIT.java
@@ -1,6 +1,8 @@
 package io.dockstore.client.cli;
 
 import io.dockstore.client.cli.nested.WesTests;
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dropwizard.testing.ResourceHelpers;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,9 +27,9 @@ public class WesToilIT {
     @Rule
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog().muteForSuccessfulTests();
 
     /**
      * Searches for a runId in the provided string using a pattern printed by the CLI during a launch. Only needed for verbose outputs.

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -34,6 +34,8 @@ import com.google.common.collect.Lists;
 import io.dockstore.client.cli.nested.WorkflowClient;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dockstore.common.SourceControl;
 import io.dockstore.common.WorkflowTest;
 import io.dropwizard.testing.ResourceHelpers;
@@ -70,9 +72,9 @@ import static org.junit.Assert.assertTrue;
 public class WorkflowIT extends BaseIT {
 
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog().muteForSuccessfulTests();
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
     @Rule
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
     @Rule

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/common/FlushingSystemErrRule.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/common/FlushingSystemErrRule.java
@@ -1,0 +1,33 @@
+package io.dockstore.common;
+
+import org.junit.contrib.java.lang.system.SystemErrRule;
+
+public class FlushingSystemErrRule extends SystemErrRule {
+
+    @SuppressWarnings("EmptyCatchBlock")
+    private void pauseAndFlush() {
+        try {
+            Thread.sleep(500);
+            System.err.flush();
+        } catch (Exception e) {
+        }
+    }
+
+    @Override
+    public String getLog() {
+        pauseAndFlush();
+        return super.getLog();
+    }
+
+    @Override
+    public byte[] getLogAsBytes() {
+        pauseAndFlush();
+        return super.getLogAsBytes();
+    }
+
+    @Override
+    public String getLogWithNormalizedLineSeparator() {
+        pauseAndFlush();
+        return super.getLogWithNormalizedLineSeparator();
+    }
+}

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/common/FlushingSystemOutRule.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/common/FlushingSystemOutRule.java
@@ -1,0 +1,33 @@
+package io.dockstore.common;
+
+import org.junit.contrib.java.lang.system.SystemOutRule;
+
+public class FlushingSystemOutRule extends SystemOutRule {
+
+    @SuppressWarnings("EmptyCatchBlock")
+    private void pauseAndFlush() {
+        try {
+            Thread.sleep(500);
+            System.out.flush();
+        } catch (Exception e) {
+        }
+    }
+
+    @Override
+    public String getLog() {
+        pauseAndFlush();
+        return super.getLog();
+    }
+
+    @Override
+    public byte[] getLogAsBytes() {
+        pauseAndFlush();
+        return super.getLogAsBytes();
+    }
+
+    @Override
+    public String getLogWithNormalizedLineSeparator() {
+        pauseAndFlush();
+        return super.getLogWithNormalizedLineSeparator();
+    }
+}

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/AbstractEntryClientTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/AbstractEntryClientTestIT.java
@@ -4,6 +4,8 @@ import io.dockstore.client.cli.nested.AbstractEntryClient;
 import io.dockstore.client.cli.nested.WesCommandParser;
 import io.dockstore.client.cli.nested.WesRequestData;
 import io.dockstore.client.cli.nested.WorkflowClient;
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dropwizard.testing.ResourceHelpers;
 import io.swagger.client.api.UsersApi;
 import io.swagger.client.api.WorkflowsApi;
@@ -27,9 +29,9 @@ public class AbstractEntryClientTestIT {
     @Rule
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog().muteForSuccessfulTests();
     @Rule
     public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/ClientTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/ClientTestIT.java
@@ -15,6 +15,8 @@
  */
 package io.dockstore.client.cli;
 
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dockstore.common.Utilities;
 import io.dropwizard.testing.ResourceHelpers;
 import io.github.collaboratory.cwl.cwlrunner.CWLRunnerFactory;
@@ -32,9 +34,9 @@ import static io.dockstore.client.cli.Client.DEPRECATED_PORT_MESSAGE;
 public class ClientTestIT {
 
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog();
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog();
 
     @Test
     public void testDependencies() {

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchNoInternetTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchNoInternetTestIT.java
@@ -8,6 +8,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dockstore.common.Utilities;
 import io.dropwizard.testing.ResourceHelpers;
 import org.apache.commons.io.FileUtils;
@@ -41,9 +43,9 @@ public class LaunchNoInternetTestIT {
     private static final String FAKE_IMAGE_NAME = "dockstore.org/bashwithbinbash:0118999881999119725...3";
     private static String dockerImageDirectory;
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog().muteForSuccessfulTests();
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
     @Rule
     public final ExpectedSystemExit exit = ExpectedSystemExit.none();
     @Rule

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
@@ -30,6 +30,8 @@ import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import io.dockstore.client.cli.nested.ToolClient;
 import io.dockstore.client.cli.nested.WorkflowClient;
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dockstore.common.Utilities;
 import io.dockstore.openapi.client.model.WorkflowSubClass;
 import io.dropwizard.testing.ResourceHelpers;
@@ -70,10 +72,10 @@ public class LaunchTestIT {
     //create tests that will call client.checkEntryFile for workflow launch with different files and descriptor
 
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog().muteForSuccessfulTests();
 
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
 
     @Rule
     public final ExpectedSystemExit exit = ExpectedSystemExit.none();

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/NextflowIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/NextflowIT.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import io.dockstore.client.cli.nested.WorkflowClient;
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dropwizard.testing.ResourceHelpers;
 import org.apache.commons.io.FileUtils;
 import org.assertj.core.util.Lists;
@@ -34,10 +36,10 @@ import org.junit.contrib.java.lang.system.SystemOutRule;
 
 public class NextflowIT {
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog().muteForSuccessfulTests();
 
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
 
     @Test
     public void demoNextflowLaunch() throws IOException {

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WesFileTest.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WesFileTest.java
@@ -1,6 +1,7 @@
 package io.dockstore.client.cli;
 
 import io.dockstore.client.cli.nested.WesFile;
+import io.dockstore.common.FlushingSystemErrRule;
 import io.dropwizard.testing.ResourceHelpers;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,7 +16,7 @@ public class WesFileTest {
     @Rule
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
 
     @Test
     public void testFileSuffixNaming() {

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WesLauncherTest.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WesLauncherTest.java
@@ -7,6 +7,8 @@ import java.util.List;
 import io.dockstore.client.cli.nested.WesLauncher;
 import io.dockstore.client.cli.nested.WesRequestData;
 import io.dockstore.client.cli.nested.WorkflowClient;
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dropwizard.testing.ResourceHelpers;
 import io.openapi.wes.client.ApiException;
 import io.openapi.wes.client.api.WorkflowExecutionServiceApi;
@@ -36,9 +38,9 @@ public class WesLauncherTest {
     @Rule
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog().muteForSuccessfulTests();
 
     public Workflow buildFakeWorkflow() {
         Workflow workflow = new Workflow();

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/WorkflowInDirectoryTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/WorkflowInDirectoryTestIT.java
@@ -18,6 +18,8 @@ package io.dockstore.client.cli;
 import java.io.File;
 import java.util.ArrayList;
 
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dropwizard.testing.ResourceHelpers;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -36,9 +38,9 @@ public class WorkflowInDirectoryTestIT {
 
     private static File configFile;
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog().muteForSuccessfulTests();
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
     /**
      * Guard against failing tests killing VM
      */

--- a/dockstore-client/src/test/java/io/dockstore/common/FlushingSystemErrRule.java
+++ b/dockstore-client/src/test/java/io/dockstore/common/FlushingSystemErrRule.java
@@ -1,0 +1,33 @@
+package io.dockstore.common;
+
+import org.junit.contrib.java.lang.system.SystemErrRule;
+
+public class FlushingSystemErrRule extends SystemErrRule {
+
+    @SuppressWarnings("EmptyCatchBlock")
+    private void pauseAndFlush() {
+        try {
+            Thread.sleep(500);
+            System.err.flush();
+        } catch (Exception e) {
+        }
+    }
+
+    @Override
+    public String getLog() {
+        pauseAndFlush();
+        return super.getLog();
+    }
+
+    @Override
+    public byte[] getLogAsBytes() {
+        pauseAndFlush();
+        return super.getLogAsBytes();
+    }
+
+    @Override
+    public String getLogWithNormalizedLineSeparator() {
+        pauseAndFlush();
+        return super.getLogWithNormalizedLineSeparator();
+    }
+}

--- a/dockstore-client/src/test/java/io/dockstore/common/FlushingSystemOutRule.java
+++ b/dockstore-client/src/test/java/io/dockstore/common/FlushingSystemOutRule.java
@@ -1,0 +1,33 @@
+package io.dockstore.common;
+
+import org.junit.contrib.java.lang.system.SystemOutRule;
+
+public class FlushingSystemOutRule extends SystemOutRule {
+
+    @SuppressWarnings("EmptyCatchBlock")
+    private void pauseAndFlush() {
+        try {
+            Thread.sleep(500);
+            System.out.flush();
+        } catch (Exception e) {
+        }
+    }
+
+    @Override
+    public String getLog() {
+        pauseAndFlush();
+        return super.getLog();
+    }
+
+    @Override
+    public byte[] getLogAsBytes() {
+        pauseAndFlush();
+        return super.getLogAsBytes();
+    }
+
+    @Override
+    public String getLogWithNormalizedLineSeparator() {
+        pauseAndFlush();
+        return super.getLogWithNormalizedLineSeparator();
+    }
+}

--- a/dockstore-client/src/test/java/io/dockstore/common/WesRequestDataTest.java
+++ b/dockstore-client/src/test/java/io/dockstore/common/WesRequestDataTest.java
@@ -16,9 +16,9 @@ public class WesRequestDataTest {
     @Rule
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog();
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog();
 
     @Test
     public void testNoCredentials() {

--- a/dockstore-client/src/test/java/io/github/collaboratory/TabExpansionTest.java
+++ b/dockstore-client/src/test/java/io/github/collaboratory/TabExpansionTest.java
@@ -15,6 +15,8 @@
  */
 package io.github.collaboratory;
 
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dockstore.common.TabExpansionUtil;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,9 +29,9 @@ import org.junit.contrib.java.lang.system.SystemOutRule;
 public class TabExpansionTest {
 
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog();
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog();
 
     @Test
     public void testForNonCrashing() {

--- a/dockstore-client/src/test/java/io/github/collaboratory/cwl/LauncherIT.java
+++ b/dockstore-client/src/test/java/io/github/collaboratory/cwl/LauncherIT.java
@@ -29,6 +29,8 @@ import com.google.gson.Gson;
 import io.dockstore.client.cli.Client;
 import io.dockstore.common.FileProvisionUtil;
 import io.dockstore.common.FileProvisioning;
+import io.dockstore.common.FlushingSystemErrRule;
+import io.dockstore.common.FlushingSystemOutRule;
 import io.dockstore.common.Utilities;
 import io.github.collaboratory.cwl.cwlrunner.CWLRunnerFactory;
 import io.github.collaboratory.cwl.cwlrunner.CWLRunnerInterface;
@@ -56,10 +58,10 @@ public abstract class LauncherIT {
     public final ExpectedSystemExit exit = ExpectedSystemExit.none();
 
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new FlushingSystemOutRule().enableLog().muteForSuccessfulTests();
 
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public final SystemErrRule systemErrRule = new FlushingSystemErrRule().enableLog().muteForSuccessfulTests();
 
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();


### PR DESCRIPTION
A CLI integration test had become very flaky and was essentially blocking development.  The problem was that all output sometimes did not completely propagate to the associated JUnit `SystemOutRule` and `SystemErrRule` objects, which the tests use to log `stdout`/`stderr`, so the test would sometimes retrieve an incomplete output and fail.  The theory is the logging system wasn't flushing, or the output was stuck in a queue/buffer and not processed by a logging thread in time, or something like that.

This PR adds a pause-and-flush before retrieving the logged stderr/stdout, via new extending classes `FlushingSystemOutRule` and `FlushingSystemErrRule`, which are instantiated as a replacement.

This PR fixes all tests in `dockstore-cli`.  Within `dockstore-cli`, there did not appear to be a good place to put the new `Flushing` classes so they were shared by both the unit tests and integration tests, so they are currently duplicated.  The same logging mechanism is used by tests in other repos, and in the interest of reducing flakiness, we should eventually fix those, too.  When we do that, we so should move the `Flushing` classes to package `io.dockstore.common` in `dockstore/dockstore-common`, at which point they'll be accessible from everywhere (I think).

The 500ms (half second) pause seems to work fine.  If we want to tighten it, we can run some experiments, it's not immediately apparent how long a pause is good enough.

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
