### PR TITLE
Move WES out of beta

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -1653,7 +1653,7 @@ public abstract class AbstractEntryClient<T> {
         out("Global Optional Parameters:");
         out("  --wes-url <WES URL>                 URL where the WES request should be sent, e.g. 'http://localhost:8080/ga4gh/wes/v1'");
         out("");
-        out("NOTE: WES SUPPORT IS IN BETA AT THIS TIME. RESULTS MAY BE UNPREDICTABLE.");
+        out("NOTE: Currently only WDL workflows are supported for WES requests. Further language support is under development.");
     }
 
     protected abstract void publishHelp();


### PR DESCRIPTION
WES support in the CLI is tested with WDL, so changed the note to that effect. I also changed the all-caps text because it seemed excessively 'loud', but can change it back if that's the recommended format for notes.

This is also seems like a good PR to finish off the develop changes and cut the release branch.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [X] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
