### PR TITLE
Feature/2083/cli info call

### DIFF
--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -159,9 +159,13 @@ public class GeneralWorkflowIT extends BaseIT {
                 "hello-dockstore-workflow", "--organization", "DockstoreTestUser2", "--git-version-control", "github", "--workflow-name",
                 "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", "wdl", "--script" });
 
-        // info
+        // info (no version)
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "info", "--entry",
             SourceControl.GITHUB.toString() + "/DockstoreTestUser2/hello-dockstore-workflow/testname", "--script" });
+
+        // info (with version)
+        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "info", "--entry",
+                SourceControl.GITHUB.toString() + "/DockstoreTestUser2/hello-dockstore-workflow/testname:master", "--script" });
 
         // unpublish
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "publish", "--entry",

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -406,7 +406,7 @@ public class WorkflowIT extends BaseIT {
         // Register and refresh workflow
         Workflow workflow = workflowApi
                 .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
-                        "test", "cwl", null);
+                        null, "cwl", null);
         Workflow refresh = workflowApi.refresh(workflow.getId(), true);
         WorkflowVersion workflowVersion = refresh.getWorkflowVersions().get(0);
 

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -405,13 +405,12 @@ public class WorkflowIT extends BaseIT {
 
         // Register and refresh workflow
         Workflow workflow = workflowApi
-                .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
-                        "", "cwl", null);
+                .manualRegister("github.com", "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
+                        "test", "cwl", null);
         Workflow refresh = workflowApi.refresh(workflow.getId(), true);
         WorkflowVersion workflowVersion = refresh.getWorkflowVersions().get(0);
-
-        final String entryWithoutVersion = workflow.getPath();
-        final String entryWithVersion = workflow.getPath() + ":" + workflowVersion.getName();
+        final String entryWithoutVersion = "github.com/DockstoreTestUser2/md5sum-checker/test";
+        final String entryWithVersion = entryWithoutVersion + ":" + workflowVersion.getName();
 
         // Both the versioned and un-versioned entry paths should succeed
         Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "info", "--entry", entryWithoutVersion });

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -414,11 +414,7 @@ public class WorkflowIT extends BaseIT {
         final String entryWithVersion = workflow.getPath() + ":" + workflowVersion.getName();
 
         // Both the versioned and un-versioned entry paths should succeed
-        Client.main(
-                new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "info", "--entry",
-                        entryWithoutVersion });
-        Client.main(
-                new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "info", "--entry",
-                        entryWithVersion });
+        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "info", "--entry", entryWithoutVersion });
+        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "info", "--entry", entryWithVersion });
     }
 }

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -395,4 +395,30 @@ public class WorkflowIT extends BaseIT {
         Client.main(args.toArray(new String[0]));
         Assert.assertTrue(systemOutRule.getLog().contains("Final process status is success"));
     }
+
+    @Test
+    public void workflowInfoTest() {
+
+        // Setup our client
+        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowApi = new WorkflowsApi(webClient);
+
+        // Register and refresh workflow
+        Workflow workflow = workflowApi
+                .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
+                        "test", "cwl", null);
+        Workflow refresh = workflowApi.refresh(workflow.getId(), true);
+        WorkflowVersion workflowVersion = refresh.getWorkflowVersions().get(0);
+
+        final String entryWithoutVersion = workflow.getPath();
+        final String entryWithVersion = workflow.getPath() + ":" + workflowVersion.getName();
+
+        // Both the versioned and un-versioned entry paths should succeed
+        Client.main(
+                new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "info", "--entry",
+                        entryWithoutVersion });
+        Client.main(
+                new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "info", "--entry",
+                        entryWithVersion });
+    }
 }

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -406,7 +406,7 @@ public class WorkflowIT extends BaseIT {
         // Register and refresh workflow
         Workflow workflow = workflowApi
                 .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
-                        null, "cwl", null);
+                        "", "cwl", null);
         Workflow refresh = workflowApi.refresh(workflow.getId(), true);
         WorkflowVersion workflowVersion = refresh.getWorkflowVersions().get(0);
 

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -395,25 +395,4 @@ public class WorkflowIT extends BaseIT {
         Client.main(args.toArray(new String[0]));
         Assert.assertTrue(systemOutRule.getLog().contains("Final process status is success"));
     }
-
-    @Test
-    public void workflowInfoTest() {
-
-        // Setup our client
-        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
-        WorkflowsApi workflowApi = new WorkflowsApi(webClient);
-
-        // Register and refresh workflow
-        Workflow workflow = workflowApi
-                .manualRegister("github.com", "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
-                        "test", "cwl", null);
-        Workflow refresh = workflowApi.refresh(workflow.getId(), true);
-        WorkflowVersion workflowVersion = refresh.getWorkflowVersions().get(0);
-        final String entryWithoutVersion = "github.com/DockstoreTestUser2/md5sum-checker/test";
-        final String entryWithVersion = entryWithoutVersion + ":" + workflowVersion.getName();
-
-        // Both the versioned and un-versioned entry paths should succeed
-        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "info", "--entry", entryWithoutVersion });
-        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "info", "--entry", entryWithVersion });
-    }
 }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WebserviceWorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WebserviceWorkflowClient.java
@@ -76,7 +76,12 @@ public class WebserviceWorkflowClient {
 
     private Workflow getDockstoreWorkflowByPath(WorkflowSubClass workflowSubClass, String entryPath) {
         try {
-            Workflow workflow = workflowsApi.getPublishedWorkflowByPath(entryPath, workflowSubClass.toString(), include, null);
+            // Split out the base path and version from the entry path
+            final String[] paths = entryPath.split(":");
+            final String basePath = paths[0];
+            final String versionName = paths.length > 1 ? paths[1] : null;
+
+            Workflow workflow = workflowsApi.getPublishedWorkflowByPath(basePath, workflowSubClass.toString(), include, versionName);
             if (workflowSubClass.equals(WorkflowSubClass.APPTOOL)) {
                 this.setFoundAppTool(true);
             }


### PR DESCRIPTION
Ticket: https://github.com/dockstore/dockstore/issues/4756

This issue was caused by a misinterpretation of the `entryPath` parameter passed to the function, which seems to be a common case with the CLI, and is most likely causing bugs throughout.

Created a followup refactor ticket to address the underlying issue: https://github.com/dockstore/dockstore/issues/4876

---

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [X] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
