### PR TITLE
Remove residual mentions of `--tsv`

### DIFF
--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
@@ -304,7 +304,6 @@ public class ClientIT extends BaseIT {
         checkCommandForHelp(new String[] { "tool", "update_tool" });
 
         checkCommandForHelp(new String[] { "tool", "convert", "entry2json" });
-        checkCommandForHelp(new String[] { "tool", "convert", "entry2tsv" });
         checkCommandForHelp(new String[] { "tool", "convert", "cwl2yaml" });
         checkCommandForHelp(new String[] { "tool", "convert", "cwl2json" });
         checkCommandForHelp(new String[] { "tool", "convert", "wdl2json" });
@@ -325,7 +324,6 @@ public class ClientIT extends BaseIT {
         checkCommandForHelp(new String[] { "tool", "convert", "cwl2yaml", "--help" });
         checkCommandForHelp(new String[] { "tool", "convert", "wdl2json", "--help" });
         checkCommandForHelp(new String[] { "tool", "convert", "entry2json", "--help" });
-        checkCommandForHelp(new String[] { "tool", "convert", "entry2tsv", "--help" });
         checkCommandForHelp(new String[] { "tool", "launch", "--help" });
         checkCommandForHelp(new String[] { "tool", "version_tag", "--help" });
         checkCommandForHelp(new String[] { "tool", "version_tag", "remove", "--help" });
@@ -339,7 +337,6 @@ public class ClientIT extends BaseIT {
         checkCommandForHelp(new String[] { "tool" });
 
         checkCommandForHelp(new String[] { "workflow", "convert", "entry2json" });
-        checkCommandForHelp(new String[] { "workflow", "convert", "entry2tsv" });
         checkCommandForHelp(new String[] { "workflow", "convert", "cwl2yaml" });
         checkCommandForHelp(new String[] { "workflow", "convert", "cwl2json" });
         checkCommandForHelp(new String[] { "workflow", "convert", "wdl2json" });
@@ -370,7 +367,6 @@ public class ClientIT extends BaseIT {
         checkCommandForHelp(new String[] { "workflow", "convert", "cwl2yaml", "--help" });
         checkCommandForHelp(new String[] { "workflow", "convert", "wd2json", "--help" });
         checkCommandForHelp(new String[] { "workflow", "convert", "entry2json", "--help" });
-        checkCommandForHelp(new String[] { "workflow", "convert", "entry2tsv", "--help" });
         checkCommandForHelp(new String[] { "workflow", "launch", "--help" });
         checkCommandForHelp(new String[] { "workflow", "version_tag", "--help" });
         checkCommandForHelp(new String[] { "workflow", "update_workflow", "--help" });

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/JCommanderUtility.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/JCommanderUtility.java
@@ -55,8 +55,6 @@ public final class JCommanderUtility {
         out("  --json <json file>                  Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs");
         out("   OR");
         out("  --yaml <yaml file>                  Parameters to the entry in Dockstore, one map for one run, an array of maps for multiple runs (only for CWL)");
-        out("   OR");
-        out("  --tsv <tsv file>                    One row corresponds to parameters for one run in the dockstore (only for CWL)");
         out("");
         out("Optional parameters:\n"
                 + "  --wdl-output-target                 Allows you to specify a remote path to provision output files to ex: s3://oicr.temp/testing-launcher/\n"

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -619,7 +619,7 @@ public abstract class AbstractEntryClient<T> {
 
     private void convert(final List<String> args) throws ApiException, IOException {
         if (args.isEmpty() || (containsHelpRequest(args) && !args.contains("cwl2json") && !args.contains("wdl2json") && !args
-                .contains("entry2json") && !args.contains("entry2tsv"))) {
+                .contains("entry2json"))) {
             convertHelp(); // Display general help
         } else {
             final String cmd = args.remove(0);
@@ -636,9 +636,6 @@ public abstract class AbstractEntryClient<T> {
                     break;
                 case "entry2json":
                     handleEntry2json(args);
-                    break;
-                case "entry2tsv":
-                    handleEntry2tsv(args);
                     break;
                 default:
                     invalid(cmd);
@@ -706,15 +703,6 @@ public abstract class AbstractEntryClient<T> {
             entry2jsonHelp();
         } else {
             final String runString = convertEntry2Json(args, true);
-            out(runString);
-        }
-    }
-
-    public void handleEntry2tsv(List<String> args) throws ApiException, IOException {
-        if (args.isEmpty() || containsHelpRequest(args)) {
-            entry2tsvHelp();
-        } else {
-            final String runString = convertEntry2Json(args, false);
             out(runString);
         }
     }
@@ -1823,24 +1811,9 @@ public abstract class AbstractEntryClient<T> {
         out("       dockstore " + getEntryType().toLowerCase() + " " + CONVERT + " cwl2yaml [parameters]");
         out("       dockstore " + getEntryType().toLowerCase() + " " + CONVERT + " wdl2json [parameters]");
         out("       dockstore " + getEntryType().toLowerCase() + " " + CONVERT + " entry2json [parameters]");
-        out("       dockstore " + getEntryType().toLowerCase() + " " + CONVERT + " entry2tsv [parameters]");
         out("");
         out("Description:");
         out("  They allow you to convert between file representations.");
-        printHelpFooter();
-    }
-
-    private void entry2tsvHelp() {
-        printHelpHeader();
-        out("Usage: dockstore " + getEntryType().toLowerCase() + " " + CONVERT + " entry2tsv --help");
-        out("       dockstore " + getEntryType().toLowerCase() + " " + CONVERT + " entry2tsv [parameters]");
-        out("");
-        out("Description:");
-        out("  Spit out a tsv run file for a given cwl document.");
-        out("");
-        out("Required parameters:");
-        out("  --entry <entry>                Complete " + getEntryType().toLowerCase()
-                + " path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow:develop)");
         printHelpFooter();
     }
 

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -494,7 +494,7 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
                         try {
                             switch (language) {
                             case CWL:
-                                conditionalErrorMessage((yamlRun != null) == (jsonRun != null), "One of  --json, --yaml, and --tsv is required", CLIENT_ERROR);
+                                conditionalErrorMessage((yamlRun != null) == (jsonRun != null), "Either --json or --yaml is required", CLIENT_ERROR);
                                 languageClientInterface.launch(entry, false, yamlRun, jsonRun, null, uuid);
                                 break;
                             case WDL:

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -1210,14 +1210,6 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
         private boolean help = false;
     }
 
-    @Parameters(separators = "=", commandDescription = "Spit out a tsv run file for a given entry.")
-    private static class CommandEntry2tsv {
-        @Parameter(names = "--entry", description = "Complete workflow path in Dockstore (ex. NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq:master)", required = true)
-        private String entry;
-        @Parameter(names = "--help", description = "Prints help for entry2json command", help = true)
-        private boolean help = false;
-    }
-
     @Parameters(separators = "=", commandDescription = "Launch an entry locally or remotely.")
     private static class CommandLaunch {
 

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -279,30 +279,6 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
         }
     }
 
-    @Override
-    public void handleEntry2tsv(List<String> args) throws ApiException, IOException {
-        String commandName = "entry2tsv";
-        String[] argv = args.toArray(new String[0]);
-        String[] argv1 = {commandName};
-        String[] both = ArrayUtils.addAll(argv1, argv);
-        CommandEntry2tsv commandEntry2tsv = new CommandEntry2tsv();
-        JCommander jc = new JCommander();
-        jc.addCommand(commandName, commandEntry2tsv);
-        jc.setProgramName("dockstore workflow convert");
-        try {
-            jc.parse(both);
-            if (commandEntry2tsv.help) {
-                printJCommanderHelp(jc, "dockstore workflow convert", commandName);
-            } else {
-                final String runString = convertWorkflow2Json(commandEntry2tsv.entry, false);
-                out(runString);
-            }
-        } catch (ParameterException e1) {
-            out(e1.getMessage());
-            printJCommanderHelp(jc, "dockstore workflow convert", commandName);
-        }
-    }
-
     private String convertWorkflow2Json(String entry, final boolean json) throws ApiException, IOException {
         // User may enter the version, so we have to extract the path
         String[] parts = entry.split(":");
@@ -1236,7 +1212,6 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
 
     @Parameters(separators = "=", commandDescription = "Spit out a tsv run file for a given entry.")
     private static class CommandEntry2tsv {
-
         @Parameter(names = "--entry", description = "Complete workflow path in Dockstore (ex. NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq:master)", required = true)
         private String entry;
         @Parameter(names = "--help", description = "Prints help for entry2json command", help = true)


### PR DESCRIPTION
This PR removes residual mentions of the command line argument `--tsv`.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
