### PR TITLE
Removed Liquibase Changeset Message from Output in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,7 @@ commands:
     steps:
       - run:
           name: run tests
-          command: mvn -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate $MAVEN_GOAL -P$TESTING_PROFILE,coverage -ntp
+          command: mvn -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate $MAVEN_GOAL -P$TESTING_PROFILE,coverage -ntp | grep  -v "^Running Changeset:"
 
   save_test_results:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,7 @@ commands:
       - run:
           name: run tests
           command: mvn -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate $MAVEN_GOAL -P$TESTING_PROFILE,coverage -ntp | grep  -v "^Running Changeset:"
-
+          # The piping grep command is a temporary fix to this issue https://github.com/liquibase/liquibase/issues/2396
   save_test_results:
     steps:
       - run:


### PR DESCRIPTION
**Description**
An update in liquibase has caused every changeset to be logged to stdout. Including messages such as,
```
Running Changeset: migrations.1.12.0.xml::topicPhaseTwoChanges::gluu (generated)
Running Changeset: migrations.1.12.0.xml::clearCwlToolTableJson::svonworl
Running Changeset: migrations.1.12.0.xml::checksumsForNullContent::coverbeck
Running Changeset: migrations.1.12.0.xml::addAppToolEvents::dyuen (generated)
Running Changeset: migrations.1.12.0.xml::orcidAuthorInfo::ktran (generated)
Running Changeset: migrations.1.13.0.xml::migrateBioToBlogLink::ktran
Running Changeset: migrations.1.13.0.xml::convertUserProfileEmptyStringToNull::ktran
Running Changeset: migrations.1.13.0.xml::add_constraints_to_user_profile::ajandu
```
which is making it difficult to determine the cause of test failures in CirlceCI. This issue has been bought to the attention of liquibase and it looks like they will fix it,

https://github.com/liquibase/liquibase/issues/2396

In the meantime I have added a `grep` to each command that produces liquibase changeset messages so that they aren't displayed in CircleCI.

This PR should be revisited when https://github.com/liquibase/liquibase/issues/2396 is resolved.

**Issue**
[SEAB-4602](https://ucsc-cgl.atlassian.net/browse/SEAB-4602)



- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
