### PR TITLE
Corrected missing space in error message

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/YamlVerifyUtility.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/YamlVerifyUtility.java
@@ -56,7 +56,7 @@ public final class YamlVerifyUtility {
     public static final String FILE_DOES_NOT_EXIST = " does not exist";
     public static final String INVALID_FILE_STRUCTURE = "Your file structure has the following errors:" + System.lineSeparator();
 
-    public static final String INVALID_YAML = " is not a valid " + YAML + "file:" + System.lineSeparator();
+    public static final String INVALID_YAML = " is not a valid " + YAML + " file:" + System.lineSeparator();
     // This message is displayed when it is determined that DOCKSTOREYML is a valid yaml file,
     // but displaying this message does NOT mean DOCKSTOREYML is a valid dockstore yaml file
     public static final String VALID_YAML_ONLY = " is a valid " + YAML + " file";


### PR DESCRIPTION
Very simple change. Realized the error message in the Yaml Validate feature for when the yaml is invalid was missing a space. This PR corrects that error. 

**Before**
```
Your .dockstore.yml is invalid:
correct-directory/.dockstore.yml is not a valid yamlfile:
```

**After**
```
Your .dockstore.yml is invalid:
correct-directory/.dockstore.yml is not a valid yaml file:
```

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [X] Check that you pass the basic style checks and unit tests by running `mvn clean install` 
