### PR TITLE
SEAB-5021:  Confirm support for CWL Version 1.2

### DIFF
--- a/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
@@ -125,7 +125,7 @@ public class LaunchTestIT {
     }
 
     @Test
-    public void cwlHandlesVersion12() {
+    public void cwlSupportsVersion12() {
         // 1st-workflow-12.cwl is a version of 1st-workflow.cwl to which key new CWL version 1.2 features have been added.
         File cwlFile = new File(ResourceHelpers.resourceFilePath("1st-workflow-12.cwl"));
         File cwlJSON = new File(ResourceHelpers.resourceFilePath("1st-workflow-job.json"));
@@ -146,7 +146,7 @@ public class LaunchTestIT {
      * cwltool should fail to run a workflow with a step of class "Operation"
      */
     @Test
-    public void cwlFailsClassOperation() {
+    public void cwlFailsStepWithClassOperation() {
         File cwlFile = new File(ResourceHelpers.resourceFilePath("class-operation.cwl"));
         File cwlJSON = new File(ResourceHelpers.resourceFilePath("1st-workflow-job.json"));
 
@@ -166,7 +166,7 @@ public class LaunchTestIT {
                 assertTrue("output should include a failed cwltool run", systemErrRule.getLog().contains("Workflow has unrunnable abstract Operation"));
             }
         });
-        runWorkflowUnchecked(cwlFile, args, api, usersApi, client, false);
+        runWorkflow(cwlFile, args, api, usersApi, client, false);
     }
 
     @Test
@@ -278,15 +278,12 @@ public class LaunchTestIT {
     }
 
 
-    private void runWorkflowUnchecked(File cwlFile, ArrayList<String> args, WorkflowsApi api, UsersApi usersApi, Client client, boolean useCache) {
+    private void runWorkflow(File cwlFile, ArrayList<String> args, WorkflowsApi api, UsersApi usersApi, Client client, boolean useCache) {
         client.setConfigFile(ResourceHelpers.resourceFilePath(useCache ? "config.withCache" : "config"));
         Client.SCRIPT.set(true);
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
         workflowClient.checkEntryFile(cwlFile.getAbsolutePath(), args, null);
-    }
 
-    private void runWorkflow(File cwlFile, ArrayList<String> args, WorkflowsApi api, UsersApi usersApi, Client client, boolean useCache) {
-        runWorkflowUnchecked(cwlFile, args, api, usersApi, client, useCache);
         assertTrue("output should include a successful cwltool run", systemOutRule.getLog().contains("Final process status is success"));
     }
 

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
@@ -124,6 +124,24 @@ public class LaunchTestIT {
     }
 
     @Test
+    public void cwlHandlesVersion12() {
+        // 1st-workflow-12.cwl is a version of 1st-workflow.cwl to which key new CWL version 1.2 features have been added.
+        File cwlFile = new File(ResourceHelpers.resourceFilePath("1st-workflow-12.cwl"));
+        File cwlJSON = new File(ResourceHelpers.resourceFilePath("1st-workflow-job.json"));
+
+        ArrayList<String> args = new ArrayList<>();
+        args.add("--local-entry");
+        args.add("--json");
+        args.add(cwlJSON.getAbsolutePath());
+
+        WorkflowsApi api = mock(WorkflowsApi.class);
+        UsersApi usersApi = mock(UsersApi.class);
+        Client client = new Client();
+        // do not use a cache
+        runWorkflow(cwlFile, args, api, usersApi, client, false);
+    }
+
+    @Test
     public void wdlMetadataNoopPluginTest() {
         //Test when content and extension are wdl  --> no need descriptor
         File helloWDL = new File(ResourceHelpers.resourceFilePath("hello.wdl"));

--- a/dockstore-client/src/test/resources/1st-workflow-12.cwl
+++ b/dockstore-client/src/test/resources/1st-workflow-12.cwl
@@ -1,0 +1,37 @@
+cwlVersion: v1.2
+class: Workflow
+requirements:
+  InlineJavascriptRequirement: {}
+
+inputs:
+  - id: inp
+    type: File
+  - id: ex
+    type: string
+
+outputs:
+  - id: classout
+    type: File
+    outputSource: "#compile/classfile"
+
+steps:
+  - id: untar
+    run: tar-param.cwl
+    in:
+      - id: tarfile
+        source: "#inp"
+      - id: extractfile
+        source: "#ex"
+    out:
+      - id: example_out
+
+  # "when" is new in CWL 1.2
+  - id: compile
+    when: $(true)
+    run: arguments.cwl
+    in:
+      - id: src
+        source: "#untar/example_out"
+    out:
+      - id: classfile
+    

--- a/dockstore-client/src/test/resources/1st-workflow-12.cwl
+++ b/dockstore-client/src/test/resources/1st-workflow-12.cwl
@@ -34,4 +34,4 @@ steps:
         source: "#untar/example_out"
     out:
       - id: classfile
-    
+

--- a/dockstore-client/src/test/resources/class-operation.cwl
+++ b/dockstore-client/src/test/resources/class-operation.cwl
@@ -1,0 +1,12 @@
+cwlVersion: v1.2
+class: Workflow
+inputs: []
+outputs: []
+steps:
+  operation:
+    run:
+      class: Operation
+      inputs: []
+      outputs: []
+    in: []
+    out: []


### PR DESCRIPTION
**Description**
This PR adds a couple of tests that help to confirm CLI compatibility with CWL version 1.2.

Per the spec, CWL changed as follows between version 1.1 and 1.2:
https://www.commonwl.org/v1.2/Workflow.html#Changelog
Not much is different.

Knowing how we parse and a bit about how the CLI is structured, my theory was that if our CLI supports CWL v1.1, and the CLI could process a v1.2 workflow that contained either a "when" clause or an "Operation", that it probably can successfully process a very large proportion of v1.2 workflows.  So, I added a test corresponding to each of those two cases.

As it turns out, the CLI processes a workflow with a step containing an "Operation" with no problems, but when cwltool is invoked to run it, it fails because an "Operation" is defined as a placeholder with undefined semantics which cannot be executed:
https://www.commonwl.org/v1.2/Workflow.html#Operation
In other words, this is expected behavior.

**Review Instructions**
Confirm the presence of the new tests, and that they pass.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5021

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
