### PR TITLE
Added a  ToilCompatibleTest class to CLI

### DIFF
--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/common/ToilCompatibleTest.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/common/ToilCompatibleTest.java
@@ -1,0 +1,23 @@
+/*
+ *    Copyright 2023 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.dockstore.common;
+
+/**
+ * These tests can also use Toil instead of cwltool as an alternative
+ * Toil installs a completely different version of cwltool, cwltest, etc. then what we are normally used to
+ */
+public interface ToilCompatibleTest {
+}

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -725,6 +725,11 @@ public class Client {
                         argsArray = args.toArray(argsArray);
                         handled = DepCommand.handleDepCommand(argsArray);
                     } else if (YAML.equals(mode)) {
+                        if (!DEBUG.get() && !INFO.get()) {
+                            // Switching log off if DEBUG or INFO is not set
+                            // yamlClient will generate unnecessary error logs
+                            root.setLevel(Level.OFF);
+                        }
                         yamlClient = new YamlClient();
                         handled = yamlClient.handleCommand(args);
                     }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -725,11 +725,6 @@ public class Client {
                         argsArray = args.toArray(argsArray);
                         handled = DepCommand.handleDepCommand(argsArray);
                     } else if (YAML.equals(mode)) {
-                        if (!DEBUG.get() && !INFO.get()) {
-                            // Switching log off if DEBUG or INFO is not set
-                            // yamlClient will generate unnecessary error logs
-                            root.setLevel(Level.OFF);
-                        }
                         yamlClient = new YamlClient();
                         handled = yamlClient.handleCommand(args);
                     }


### PR DESCRIPTION
**Description**
The CLI requires the use of the `ToilCompatibleTest` class. However, `ToilCompatibleTest` class was recently removed from `dockstore/dockstore` in this [PR](https://github.com/dockstore/dockstore/pull/5297). Meaning that the CLI cannot run off the current `dockstore/dockstore` repo. This PR adds the `ToilCompatibleTest` to the CLI.


**Review Instructions**
To review this ticket, you should

- [ ] Verify that the CLI builds correctly with the current `dockstore/dockstore` repo

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.


\