### PR TITLE
DOCK-2219: removed upgrade to unstable version message

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -413,9 +413,7 @@ public class Client {
                         out("Download complete. You are now on version " + latestUnstable + " of Dockstore.");
                     } else {
                         //user input '--upgrade' without knowing the version or the optional commands
-                        out("You are running the latest stable version...");
-                        out("If you wish to upgrade to the newest unstable version, please use the following command:");
-                        out("   dockstore --upgrade-unstable"); // takes you to the newest unstable version
+                        out("You are running the latest stable version.");
                     }
                 } else {    //current is not the most stable version
                     switch (optVal) {
@@ -427,8 +425,7 @@ public class Client {
                     case "none":
                         if (compareVersion(currentVersion)) {
                             // current version is the latest unstable version
-                            out("You are currently on the latest unstable version. If you wish to upgrade to the latest stable version, please use the following command:");
-                            out("   dockstore --upgrade-stable");
+                            out("You are currently on the latest unstable version.");
                         } else {
                             // current version is the older unstable version
                             // upgrade to latest stable version
@@ -576,9 +573,7 @@ public class Client {
         }
         //check if the current version is the latest stable version or not
         if (Objects.equals(currentVersion, latestVersion)) {
-            out("You are running the latest stable version...");
-            out("If you wish to upgrade to the latest unstable version, please use the following command:");
-            out("   dockstore --upgrade-unstable"); // takes you to the newest unstable version
+            out("You are running the latest stable version."); // takes you to the newest unstable version
         } else {
             //not the latest stable version, could be on the newest unstable or older unstable/stable version
             out("The latest stable version is " + latestVersion);


### PR DESCRIPTION
**Description**
This PR removes the `upgrade-unstable` message in both `dockstore --upgrade` and `dockstore --version`

**Review Instructions**
Review that the message is removed accordingly.

**Issue**
https://github.com/dockstore/dockstore/issues/5054

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
