### PR TITLE
update vfs, hook-up cromwell for progress bar

### DIFF
--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -23,7 +23,7 @@ Lists of 396 third-party dependencies.
      (Apache License, Version 2.0) Apache Commons Net (commons-net:commons-net:3.9.0 - https://commons.apache.org/proper/commons-net/)
      (Apache License, Version 2.0) Apache Commons Text (org.apache.commons:commons-text:1.10.0 - https://commons.apache.org/proper/commons-text)
      (Apache License, Version 2.0) Apache Commons Validator (commons-validator:commons-validator:1.7 - http://commons.apache.org/proper/commons-validator/)
-     (Apache License, Version 2.0) Apache Commons VFS (org.apache.commons:commons-vfs2:2.3 - http://commons.apache.org/proper/commons-vfs/)
+     (Apache License, Version 2.0) Apache Commons VFS (org.apache.commons:commons-vfs2:2.9.0 - http://commons.apache.org/proper/commons-vfs/)
      (The Apache Software License, Version 2.0) Apache Groovy (org.codehaus.groovy:groovy:2.5.14 - https://groovy-lang.org)
      (The Apache Software License, Version 2.0) Apache HTTP transport v2 for the Google HTTP Client Library for Java. (com.google.http-client:google-http-client-apache-v2:1.41.8 - https://github.com/googleapis/google-http-java-client/google-http-client-apache-v2)
      (Apache License, Version 2.0) Apache HttpAsyncClient (org.apache.httpcomponents:httpasyncclient:4.1.4 - http://hc.apache.org/httpcomponents-asyncclient)

--- a/dockstore-client/generated/src/main/resources/pom.xml
+++ b/dockstore-client/generated/src/main/resources/pom.xml
@@ -273,12 +273,16 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
-      <version>2.3</version>
+      <version>2.9.0</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
           <groupId>commons-httpclient</groupId>
           <artifactId>commons-httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs-client</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -269,10 +269,16 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-vfs2</artifactId>
+            <!-- remove after bom is updated with Dockstore or above 1.14.0 -->
+            <version>2.9.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-httpclient</groupId>
                     <artifactId>commons-httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-hdfs-client</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/CromwellLauncher.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/CromwellLauncher.java
@@ -14,7 +14,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import com.google.gson.Gson;
 import io.dockstore.common.DescriptorLanguage;
@@ -23,7 +22,6 @@ import io.dockstore.common.Utilities;
 import io.dockstore.common.WdlBridge;
 import io.github.collaboratory.cwl.CWLClient;
 import org.apache.commons.configuration2.INIConfiguration;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import wdl.draft3.parser.WdlParser;
 
@@ -79,11 +77,8 @@ public class CromwellLauncher extends BaseLauncher {
         String cromwellTarget = libraryLocation + cromwellFileName;
         File cromwellTargetFile = new File(cromwellTarget);
         if (!cromwellTargetFile.exists()) {
-            try {
-                FileUtils.copyURLToFile(cromwellURL, cromwellTargetFile);
-            } catch (IOException e) {
-                throw new RuntimeException("Could not download " + launcherName + " location", e);
-            }
+            final int pluginDownloadAttempts = 5;
+            FileProvisioning.retryWrapper(null, cromwellURL.toString(), cromwellTargetFile.toPath(), pluginDownloadAttempts, true, 1);
         }
         executionFile = cromwellTargetFile;
     }
@@ -96,7 +91,7 @@ public class CromwellLauncher extends BaseLauncher {
         if (cromwellVmOptions.size() > 0) {
             List<String> cromwellVmOptionsParsed = cromwellVmOptions.stream().map(string -> string.split(","))
                     .flatMap(Arrays::stream).map(String::trim)
-                    .collect(Collectors.toList());
+                    .toList();
             arguments.addAll(cromwellVmOptionsParsed);
         }
 
@@ -119,7 +114,7 @@ public class CromwellLauncher extends BaseLauncher {
         if (cromwellExtraParameters.size() > 0) {
             List<String> cromwellExtraParametersParsed = cromwellExtraParameters.stream().map(string -> string.split(","))
                     .flatMap(Arrays::stream).map(String::trim)
-                    .collect(Collectors.toList());
+                    .toList();
             arguments.addAll(cromwellExtraParametersParsed);
         }
 

--- a/dockstore-client/src/main/java/io/dockstore/common/FileProvisionUtil.java
+++ b/dockstore-client/src/main/java/io/dockstore/common/FileProvisionUtil.java
@@ -85,7 +85,7 @@ public final class FileProvisionUtil {
         class CustomHttp4sFileProvider extends Http4sFileProvider {
             public HttpClientContext createHttpClientContext(final Http4FileSystemConfigBuilder builder,
                                                              final GenericFileName rootName, final FileSystemOptions fileSystemOptions,
-                                                             final UserAuthenticationData authData) throws FileSystemException {
+                                                             final UserAuthenticationData authData) {
 
                 HttpClientContext def = super.createHttpClientContext(builder, rootName, fileSystemOptions, authData);
                 if (rootName.getHostName().equals("github.com")) {

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,12 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- remove after bom is updated with Dockstore or above 1.14.0 -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-vfs2</artifactId>
+                <version>2.9.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
**Description**
Add a progress bar to cromwell provisioning by using vfs2
https://github.com/dockstore/dockstore/issues/1520

**Review Instructions**
1. Remove `~/.dockstore/self-installs/` and `~/.dockstore/libraries/`
2. Run just `dockstore` and see progress bar for our jar
3. Run `dockstore workflow launch --entry github.com/dockstore-testing/Metaphlan-WDL:master --json Dockstore.json` with any `json` stub and see progress bar for cromwell

**Issue**
https://github.com/dockstore/dockstore/issues/1520

**Security**
None
Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
