### PR TITLE
Display server-url

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -644,7 +644,7 @@ public class Client {
             final Metadata metadata = ga4ghApi.metadataGet();
             final Gson gson = io.cwl.avro.CWL.getTypeSafeCWLToolDocument();
             out(gson.toJson(metadata));
-            out("server-url: " + serverUrl);
+            out("Dockstore server: " + serverUrl);
         } catch (ApiException ex) {
             exceptionMessage(ex, "", API_ERROR);
         } catch (CWL.GsonBuildException ex) {

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -113,6 +113,7 @@ public class Client {
     private static ObjectMapper objectMapper;
 
     private String configFile = null;
+    private String serverUrl = null;
     private Ga4GhApi ga4ghApi;
     private Ga4Ghv20Api ga4ghv20Api;
     private ExtendedGa4GhApi extendedGA4GHApi;
@@ -643,6 +644,7 @@ public class Client {
             final Metadata metadata = ga4ghApi.metadataGet();
             final Gson gson = io.cwl.avro.CWL.getTypeSafeCWLToolDocument();
             out(gson.toJson(metadata));
+            out("server-url: " + serverUrl);
         } catch (ApiException ex) {
             exceptionMessage(ex, "", API_ERROR);
         } catch (CWL.GsonBuildException ex) {
@@ -663,7 +665,7 @@ public class Client {
         final String cacheDirectory = getCacheDirectory(configuration);
         FileUtils.deleteDirectory(new File(cacheDirectory));
     }
-
+    
     private void run(String[] argv) {
         List<String> args = new ArrayList<>(Arrays.asList(argv));
 
@@ -795,7 +797,7 @@ public class Client {
         INIConfiguration config = getIniConfiguration(args);
         // pull out the variables from the config
         String token = config.getString("token", "");
-        String serverUrl = config.getString("server-url", "https://dockstore.org/api");
+        serverUrl = config.getString("server-url", "https://dockstore.org/api");
         if (serverUrl.contains(":8443")) {
             err(DEPRECATED_PORT_MESSAGE);
         }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -665,7 +665,7 @@ public class Client {
         final String cacheDirectory = getCacheDirectory(configuration);
         FileUtils.deleteDirectory(new File(cacheDirectory));
     }
-    
+
     private void run(String[] argv) {
         List<String> args = new ArrayList<>(Arrays.asList(argv));
 


### PR DESCRIPTION
**Description**
Ever changed your `config` file and forgot which server you were accessing? Well we have a solution for you ;)  This pr adds the `server-url` from your config file to the existing `--server-metadata` command.

Example output:
```
$ dockstore --server-metadata
{
  "apiVersion": "2.0.0",
  "country": "CAN",
  "friendlyName": "Dockstore",
  "version": "1.13.1"
}
server-url: https://dockstore.org/api
```
Charles brought up a great observation that this command is using the TRS 2.0.0-beta.2 API similar to a [previous ticket](https://ucsc-cgl.atlassian.net/browse/DOCK-2300) so I've also created a [new ticket](https://ucsc-cgl.atlassian.net/browse/SEAB-5206) to switch to the TRS 2.0.0 API.

**Review Instructions**
Build changes and run the `--server-metadata` command, ensure the `server-url` printed matches `~/.dockstore/config`

**Issue**
[DOCK-2198
](https://ucsc-cgl.atlassian.net/browse/DOCK-2198)[GitHub issue
](https://github.com/dockstore/dockstore/issues/5013)
**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
