### PR TITLE
Made error messages in CLI more user friendly

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/ArgumentUtility.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/ArgumentUtility.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 public final class ArgumentUtility {
 
     public static final String CONVERT = "convert";
+    public static final String ERROR_MESSAGE_START = "ERROR: ";
     public static final String LAUNCH = "launch";
     public static final String DOWNLOAD = "download";
     public static final String NAME_HEADER = "NAME";
@@ -57,11 +58,19 @@ public final class ArgumentUtility {
     }
 
     public static void err(String arg) {
-        LOG.error(arg);
+        if (LOG.isDebugEnabled()) {
+            LOG.error(arg);
+        } else {
+            out(ERROR_MESSAGE_START + arg);
+        }
     }
 
     private static void errFormatted(String format, Object... args) {
-        LOG.error((String.format(format, args)));
+        if (LOG.isDebugEnabled()) {
+            LOG.error(String.format(format, args));
+        } else {
+            out(String.format(ERROR_MESSAGE_START + format, args));
+        }
     }
 
     private static void kill(String format, Object... args) {
@@ -78,9 +87,12 @@ public final class ArgumentUtility {
     public static void exceptionMessage(Exception exception, String message, int exitCode) {
         if (!"".equals(message)) {
             err(message);
+        } else if (!"".equals(exception.getMessage()) && !LOG.isDebugEnabled()) {
+            err(exception.getMessage());
         }
-        err(ExceptionUtils.getStackTrace(exception));
-
+        if (LOG.isDebugEnabled()) {
+            err(ExceptionUtils.getStackTrace(exception));
+        }
         if (exitCode != 0) {
             System.exit(exitCode);
         }


### PR DESCRIPTION
**Description**
This PR improves the readability of error messages given in the CLI. If the `--debug` or `--info` is **not** given then the CLI will only display
```
ERROR: <Error message>
```


**Review Instructions**
Describe if this ticket needs review and if so, how one may go about it in qa and/or staging environments.
For example, a ticket based on Security Hub, Snyk, or Dependabot may not need review since those services
will generate new warnings if the issue has not been resolved properly. On the other hand, an infrastructure
ticket that results in visible changes to the end-user will definitely require review.
Many tickets will likely be between these two extremes, so some judgement may be required.

**Issue**
https://github.com/dockstore/dockstore/issues/5223
[DOCK-2275](https://ucsc-cgl.atlassian.net/browse/DOCK-2275)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
