### PR TITLE
Fix Incorrect WDL validation

### DIFF
--- a/dockstore-client/src/main/java/io/github/collaboratory/wdl/WDLClient.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/wdl/WDLClient.java
@@ -228,7 +228,6 @@ public class WDLClient extends BaseLanguageClient implements LanguageClientInter
                 return false;   // not a WDL file, maybe a CWL file or something else
             } else {
                 // WDL file but some required fields are missing
-                Boolean missingPotentiallyRequiredField = false;
                 String missingPotentiallyRequiredFields = "";
                 String missingRequiredFields = "";
                 if (counter == 0) {

--- a/dockstore-client/src/main/java/io/github/collaboratory/wdl/WDLClient.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/wdl/WDLClient.java
@@ -243,11 +243,11 @@ public class WDLClient extends BaseLanguageClient implements LanguageClientInter
                     missing += " '" + WORKFLOW + "'";
                 }
                 if (!commandFound) {
-                    missing += " '" + COMMAND + "'";
+                    missingPotentiallyRequiredFields += " '" + COMMAND + "'";
+                    missingPotentiallyRequiredField = true;
                 }
                 if (!callFound) {
-                    missingPotentiallyRequiredFields += " '" + CALL + "'";
-                    missingPotentiallyRequiredField = true;
+                    missing += " '" + CALL + "'";
                 }
                 if (!outputFound) {
                     missingPotentiallyRequiredFields += " '" + OUTPUT + "'";

--- a/dockstore-client/src/main/java/io/github/collaboratory/wdl/WDLClient.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/wdl/WDLClient.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,14 +54,15 @@ import static io.dockstore.client.cli.Client.CLIENT_ERROR;
 import static io.dockstore.client.cli.Client.IO_ERROR;
 import static io.dockstore.client.cli.Client.SCRIPT;
 import static io.dockstore.client.cli.Client.WORKFLOW;
+import static java.lang.String.join;
 
 /**
  * Grouping code for launching WDL tools and workflows
  */
 public class WDLClient extends BaseLanguageClient implements LanguageClientInterface {
 
-    public static final String WDL_CHECK_WARNING_MESSAGE = "WARNING: these fields are missing from WDL file, this could be causing errors:";
-    public static final String WDL_CHECK_ERROR_MESSAGE = "Required fields that are missing from WDL file:";
+    public static final String WDL_CHECK_WARNING_MESSAGE = "WARNING: these fields are missing from WDL file, this could be causing errors: ";
+    public static final String WDL_CHECK_ERROR_MESSAGE = "Required fields that are missing from WDL file: ";
     public static final String TASK = "task";
     public static final String CALL = "call";
     public static final String OUTPUT = "output";
@@ -207,20 +209,20 @@ public class WDLClient extends BaseLanguageClient implements LanguageClientInter
             }
             // check all the required fields and give error message if it's missing
             if (wfFound && callFound) {
-                String missingPotentiallyRequiredFields = "";
+                List<String> missingPotentiallyRequiredFields = new ArrayList<>();
                 if (counter == 0) {
-                    missingPotentiallyRequiredFields += " '" + TASK + "'";
+                    missingPotentiallyRequiredFields.add("'" + TASK + "'");
                 }
                 if (!commandFound) {
-                    missingPotentiallyRequiredFields += " '" + COMMAND + "'";
+                    missingPotentiallyRequiredFields.add("'" + COMMAND + "'");
                 }
                 if (!outputFound) {
-                    missingPotentiallyRequiredFields += " '" + OUTPUT + "'";
+                    missingPotentiallyRequiredFields.add("'" + OUTPUT + "'");
                 }
 
                 if (!missingPotentiallyRequiredFields.isEmpty()) {
                     // Gives user a warning if their entry file doesn't contain task, call, or output
-                    out(WDL_CHECK_WARNING_MESSAGE + missingPotentiallyRequiredFields);
+                    out(WDL_CHECK_WARNING_MESSAGE + join(" ", missingPotentiallyRequiredFields));
                 }
 
                 return true;    // this is potentially valid WDL file
@@ -228,28 +230,28 @@ public class WDLClient extends BaseLanguageClient implements LanguageClientInter
                 return false;   // not a WDL file, maybe a CWL file or something else
             } else {
                 // WDL file but some required fields are missing
-                String missingPotentiallyRequiredFields = "";
-                String missingRequiredFields = "";
+                List<String> missingPotentiallyRequiredFields = new ArrayList<>();
+                List<String> missingRequiredFields = new ArrayList<>();
                 if (counter == 0) {
-                    missingPotentiallyRequiredFields += " '" + TASK + "'";
+                    missingPotentiallyRequiredFields.add("'" + TASK + "'");
                 }
                 if (!wfFound) {
-                    missingRequiredFields += " '" + WORKFLOW + "'";
+                    missingRequiredFields.add("'" + WORKFLOW + "'");
                 }
                 if (!commandFound) {
-                    missingPotentiallyRequiredFields += " '" + COMMAND + "'";
+                    missingPotentiallyRequiredFields.add("'" + COMMAND + "'");
                 }
                 if (!callFound) {
-                    missingRequiredFields += " '" + CALL + "'";
+                    missingRequiredFields.add("'" + CALL + "'");
                 }
                 if (!outputFound) {
-                    missingPotentiallyRequiredFields += " '" + OUTPUT + "'";
+                    missingPotentiallyRequiredFields.add("'" + OUTPUT + "'");
                 }
 
                 if (!missingPotentiallyRequiredFields.isEmpty()) {
-                    out(WDL_CHECK_WARNING_MESSAGE + missingPotentiallyRequiredFields);
+                    out(WDL_CHECK_WARNING_MESSAGE + join(" ", missingPotentiallyRequiredFields));
                 }
-                errorMessage(WDL_CHECK_ERROR_MESSAGE + missingRequiredFields, CLIENT_ERROR);
+                errorMessage(WDL_CHECK_ERROR_MESSAGE + join(" ", missingRequiredFields), CLIENT_ERROR);
             }
 
         } catch (IOException e) {

--- a/dockstore-client/src/main/java/io/github/collaboratory/wdl/WDLClient.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/wdl/WDLClient.java
@@ -184,8 +184,6 @@ public class WDLClient extends BaseLanguageClient implements LanguageClientInter
         Pattern outputPattern = Pattern.compile("(.*)(output)(.*)");
         boolean wfFound = false, commandFound = false, outputFound = false, callFound = false;
         int counter = 0;
-        String missing = WDL_CHECK_ERROR_MESSAGE;
-        String missingPotentiallyRequiredFields = WDL_CHECK_WARNING_MESSAGE;
         Path p = Paths.get(content.getPath());
         try {
             List<String> fileContent = java.nio.file.Files.readAllLines(p, StandardCharsets.UTF_8);
@@ -207,25 +205,22 @@ public class WDLClient extends BaseLanguageClient implements LanguageClientInter
                     outputFound = true;
                 }
             }
-            //check all the required fields and give error message if it's missing
+            // check all the required fields and give error message if it's missing
             if (wfFound && callFound) {
-                Boolean missingPotentiallyRequiredField = false;
+                String missingPotentiallyRequiredFields = "";
                 if (counter == 0) {
                     missingPotentiallyRequiredFields += " '" + TASK + "'";
-                    missingPotentiallyRequiredField = true;
                 }
                 if (!commandFound) {
                     missingPotentiallyRequiredFields += " '" + COMMAND + "'";
-                    missingPotentiallyRequiredField = true;
                 }
                 if (!outputFound) {
                     missingPotentiallyRequiredFields += " '" + OUTPUT + "'";
-                    missingPotentiallyRequiredField = true;
                 }
 
-                if (missingPotentiallyRequiredField) {
+                if (!missingPotentiallyRequiredFields.isEmpty()) {
                     // Gives user a warning if their entry file doesn't contain task, call, or output
-                    out(missingPotentiallyRequiredFields);
+                    out(WDL_CHECK_WARNING_MESSAGE + missingPotentiallyRequiredFields);
                 }
 
                 return true;    // this is potentially valid WDL file
@@ -234,30 +229,28 @@ public class WDLClient extends BaseLanguageClient implements LanguageClientInter
             } else {
                 // WDL file but some required fields are missing
                 Boolean missingPotentiallyRequiredField = false;
-
+                String missingPotentiallyRequiredFields = "";
+                String missingRequiredFields = "";
                 if (counter == 0) {
                     missingPotentiallyRequiredFields += " '" + TASK + "'";
-                    missingPotentiallyRequiredField = true;
                 }
                 if (!wfFound) {
-                    missing += " '" + WORKFLOW + "'";
+                    missingRequiredFields += " '" + WORKFLOW + "'";
                 }
                 if (!commandFound) {
                     missingPotentiallyRequiredFields += " '" + COMMAND + "'";
-                    missingPotentiallyRequiredField = true;
                 }
                 if (!callFound) {
-                    missing += " '" + CALL + "'";
+                    missingRequiredFields += " '" + CALL + "'";
                 }
                 if (!outputFound) {
                     missingPotentiallyRequiredFields += " '" + OUTPUT + "'";
-                    missingPotentiallyRequiredField = true;
                 }
 
-                if (missingPotentiallyRequiredField) {
-                    out(missingPotentiallyRequiredFields);
+                if (!missingPotentiallyRequiredFields.isEmpty()) {
+                    out(WDL_CHECK_WARNING_MESSAGE + missingPotentiallyRequiredFields);
                 }
-                errorMessage(missing, CLIENT_ERROR);
+                errorMessage(WDL_CHECK_ERROR_MESSAGE + missingRequiredFields, CLIENT_ERROR);
             }
 
         } catch (IOException e) {

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
@@ -633,7 +633,7 @@ class LaunchTestIT {
 
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
         catchSystemExit(() -> workflowClient.checkEntryFile(file.getAbsolutePath(), args, null));
-        assertTrue(systemOutRule.getText().contains(WDL_CHECK_WARNING_MESSAGE + " '" + TASK + "' '" + COMMAND + "' '" + OUTPUT + "'"),
+        assertTrue(systemOutRule.getText().contains(WDL_CHECK_WARNING_MESSAGE + "'" + TASK + "' '" + COMMAND + "' '" + OUTPUT + "'"),
                 "output should include an error message and exit");
 
         assertTrue(systemErrRule.getText().contains(ERROR_MESSAGE_START));
@@ -686,7 +686,7 @@ class LaunchTestIT {
 
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
         catchSystemExit(() -> workflowClient.checkEntryFile(file.getAbsolutePath(), args, null));
-        assertTrue(systemOutRule.getText().contains(WDL_CHECK_WARNING_MESSAGE + " '" + COMMAND + "'"),
+        assertTrue(systemOutRule.getText().contains(WDL_CHECK_WARNING_MESSAGE + "'" + COMMAND + "'"),
                 "output should contain a warning that command is missing");
         assertTrue(systemErrRule.getText().contains(ERROR_MESSAGE_START),
                 "given that noCommand.wdl is an invalid WDL, an error message should be given");
@@ -715,7 +715,7 @@ class LaunchTestIT {
 
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
         catchSystemExit(() -> workflowClient.checkEntryFile(file.getAbsolutePath(), args, null));
-        assertTrue(systemErrRule.getText().contains(WDL_CHECK_ERROR_MESSAGE + " '" + WORKFLOW + "'"),
+        assertTrue(systemErrRule.getText().contains(WDL_CHECK_ERROR_MESSAGE + "'" + WORKFLOW + "'"),
                 "output should include an error message and exit");
     }
 
@@ -741,7 +741,7 @@ class LaunchTestIT {
 
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
         catchSystemExit(() -> workflowClient.checkEntryFile(file.getAbsolutePath(), args, null));
-        assertTrue(systemOutRule.getText().contains(WDL_CHECK_WARNING_MESSAGE + " '" + TASK + "' '" + COMMAND + "' '" + OUTPUT + "'"),
+        assertTrue(systemOutRule.getText().contains(WDL_CHECK_WARNING_MESSAGE + "'" + TASK + "' '" + COMMAND + "' '" + OUTPUT + "'"),
                 "output should contain a warning that task, command and output are missing");
         assertTrue(systemErrRule.getText().contains(ERROR_MESSAGE_START),
                 "given that wfAndCallOnly.wdl is an invalid WDL, an error message should be given");
@@ -769,9 +769,9 @@ class LaunchTestIT {
 
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
         catchSystemExit(() -> workflowClient.checkEntryFile(file.getAbsolutePath(), args, null));
-        assertTrue(systemOutRule.getText().contains(WDL_CHECK_WARNING_MESSAGE + " '" + TASK + "' '" +  OUTPUT + "'"),
+        assertTrue(systemOutRule.getText().contains(WDL_CHECK_WARNING_MESSAGE + "'" + TASK + "' '" +  OUTPUT + "'"),
                 "output should include an error message that task and output are missing");
-        assertTrue(systemErrRule.getText().contains(WDL_CHECK_ERROR_MESSAGE + " '" + WORKFLOW + "' '" + CALL + "'"),
+        assertTrue(systemErrRule.getText().contains(WDL_CHECK_ERROR_MESSAGE + "'" + WORKFLOW + "' '" + CALL + "'"),
                 "stderr should have an error that says workflow and call are missing");
 
 

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
@@ -65,6 +65,7 @@ import static io.github.collaboratory.wdl.WDLClient.WDL_CHECK_WARNING_MESSAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -639,7 +640,7 @@ class LaunchTestIT {
     }
 
     @Test
-    void wdlWithSubWorkflows() throws Exception {
+    void wdlWithSubWorkflows() {
 
         //Tests if file provisioning can handle a json parameter that specifies a file path containing spaces
         File workflowWDL = new File(ResourceHelpers.resourceFilePath("sub-workflow-test.wdl"));
@@ -653,8 +654,12 @@ class LaunchTestIT {
         args.add(JSON);
         args.add(workflowJSON.getPath());
 
-        File config = new File(ResourceHelpers.resourceFilePath("clientConfig"));
-        runClientCommandConfig(args, config);
+        try {
+            File config = new File(ResourceHelpers.resourceFilePath("clientConfig"));
+            runClientCommandConfig(args, config);
+        } catch (Exception ex) {
+            fail("Workflow that should pass caused an exception");
+        }
 
     }
 

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
@@ -687,8 +687,10 @@ class LaunchTestIT {
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
         catchSystemExit(() -> workflowClient.checkEntryFile(file.getAbsolutePath(), args, null));
         assertTrue(systemOutRule.getText().contains(WDL_CHECK_WARNING_MESSAGE + " '" + COMMAND + "'"),
-                "output should include an error message and exit");
-        assertTrue(systemErrRule.getText().contains(ERROR_MESSAGE_START));
+                "output should contain a warning that command is missing");
+        assertTrue(systemErrRule.getText().contains(ERROR_MESSAGE_START),
+                "given that noCommand.wdl is an invalid WDL, an error message should be given");
+
     }
 
     @Test
@@ -740,8 +742,9 @@ class LaunchTestIT {
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
         catchSystemExit(() -> workflowClient.checkEntryFile(file.getAbsolutePath(), args, null));
         assertTrue(systemOutRule.getText().contains(WDL_CHECK_WARNING_MESSAGE + " '" + TASK + "' '" + COMMAND + "' '" + OUTPUT + "'"),
-                "output should include an error message and exit");
-        assertTrue(systemErrRule.getText().contains(ERROR_MESSAGE_START));
+                "output should contain a warning that task, command and output are missing");
+        assertTrue(systemErrRule.getText().contains(ERROR_MESSAGE_START),
+                "given that wfAndCallOnly.wdl is an invalid WDL, an error message should be given");
     }
 
     @Test
@@ -767,8 +770,9 @@ class LaunchTestIT {
         WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
         catchSystemExit(() -> workflowClient.checkEntryFile(file.getAbsolutePath(), args, null));
         assertTrue(systemOutRule.getText().contains(WDL_CHECK_WARNING_MESSAGE + " '" + TASK + "' '" +  OUTPUT + "'"),
-                "output should include an error message and exit");
-        assertTrue(systemErrRule.getText().contains(WDL_CHECK_ERROR_MESSAGE + " '" + WORKFLOW + "' '" + CALL + "'"));
+                "output should include an error message that task and output are missing");
+        assertTrue(systemErrRule.getText().contains(WDL_CHECK_ERROR_MESSAGE + " '" + WORKFLOW + "' '" + CALL + "'"),
+                "stderr should have an error that says workflow and call are missing");
 
 
     }

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/LaunchTestIT.java
@@ -56,6 +56,7 @@ import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
 import static io.dockstore.client.cli.nested.WesCommandParser.JSON;
 import static io.dockstore.common.DescriptorLanguage.CWL;
 import static io.dockstore.common.DescriptorLanguage.WDL;
+import static io.github.collaboratory.wdl.WDLClient.CALL;
 import static io.github.collaboratory.wdl.WDLClient.COMMAND;
 import static io.github.collaboratory.wdl.WDLClient.OUTPUT;
 import static io.github.collaboratory.wdl.WDLClient.TASK;
@@ -709,6 +710,62 @@ class LaunchTestIT {
         catchSystemExit(() -> workflowClient.checkEntryFile(file.getAbsolutePath(), args, null));
         assertTrue(systemErrRule.getText().contains(WDL_CHECK_ERROR_MESSAGE + " '" + WORKFLOW + "'"),
                 "output should include an error message and exit");
+    }
+
+    @Test
+    void wdlWorkflowAndCallOnly() throws Exception {
+        //Test when content only contains 'workflow' and 'call'
+
+        File file = new File(ResourceHelpers.resourceFilePath("wfAndCallOnly.wdl"));
+        File json = new File(ResourceHelpers.resourceFilePath("hello.json"));
+
+        ArrayList<String> args = new ArrayList<>();
+        args.add(ENTRY);
+        args.add(file.getAbsolutePath());
+        args.add("--local-entry");
+        args.add(JSON);
+        args.add(json.getAbsolutePath());
+
+        WorkflowsApi api = mock(WorkflowsApi.class);
+        UsersApi usersApi = mock(UsersApi.class);
+        Client client = new Client();
+        client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
+        Client.SCRIPT.set(true);
+
+        WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
+        catchSystemExit(() -> workflowClient.checkEntryFile(file.getAbsolutePath(), args, null));
+        assertTrue(systemOutRule.getText().contains(WDL_CHECK_WARNING_MESSAGE + " '" + TASK + "' '" + COMMAND + "' '" + OUTPUT + "'"),
+                "output should include an error message and exit");
+        assertTrue(systemErrRule.getText().contains(ERROR_MESSAGE_START));
+    }
+
+    @Test
+    void wdlCommandOnly() throws Exception {
+        //Test when content is only 'command'
+
+        File file = new File(ResourceHelpers.resourceFilePath("commandOnly.wdl"));
+        File json = new File(ResourceHelpers.resourceFilePath("hello.json"));
+
+        ArrayList<String> args = new ArrayList<>();
+        args.add(ENTRY);
+        args.add(file.getAbsolutePath());
+        args.add("--local-entry");
+        args.add(JSON);
+        args.add(json.getAbsolutePath());
+
+        WorkflowsApi api = mock(WorkflowsApi.class);
+        UsersApi usersApi = mock(UsersApi.class);
+        Client client = new Client();
+        client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
+        Client.SCRIPT.set(true);
+
+        WorkflowClient workflowClient = new WorkflowClient(api, usersApi, client, false);
+        catchSystemExit(() -> workflowClient.checkEntryFile(file.getAbsolutePath(), args, null));
+        assertTrue(systemOutRule.getText().contains(WDL_CHECK_WARNING_MESSAGE + " '" + TASK + "' '" +  OUTPUT + "'"),
+                "output should include an error message and exit");
+        assertTrue(systemErrRule.getText().contains(WDL_CHECK_ERROR_MESSAGE + " '" + WORKFLOW + "' '" + CALL + "'"));
+
+
     }
 
     @Test

--- a/dockstore-client/src/test/resources/commandOnly.wdl
+++ b/dockstore-client/src/test/resources/commandOnly.wdl
@@ -1,0 +1,1 @@
+command

--- a/dockstore-client/src/test/resources/sub-workflow-task.wdl
+++ b/dockstore-client/src/test/resources/sub-workflow-task.wdl
@@ -1,0 +1,24 @@
+version 1.0
+# This workflow test was taken directly from here https://github.com/openwdl/learn-wdl/tree/master/1_script_examples/1_hello_worlds/7_subworkflow
+
+workflow HelloTask {
+    # Lines 5-7 are optional. Added for readability
+    input {
+        String name
+    }
+    call WriteGreeting
+}
+
+task WriteGreeting {
+    input {
+        String name
+    }
+    command {
+        echo 'hello ${name}!'
+    }
+    output {
+        File response = stdout()
+    }
+}
+
+

--- a/dockstore-client/src/test/resources/sub-workflow-test.json
+++ b/dockstore-client/src/test/resources/sub-workflow-test.json
@@ -1,0 +1,3 @@
+{
+  "HelloWorld.name": "Hello subworkflow"
+}

--- a/dockstore-client/src/test/resources/sub-workflow-test.wdl
+++ b/dockstore-client/src/test/resources/sub-workflow-test.wdl
@@ -1,0 +1,15 @@
+version 1.0
+# This workflow test was taken directly from here https://github.com/openwdl/learn-wdl/tree/master/1_script_examples/1_hello_worlds/7_subworkflow
+
+import "sub-workflow-task.wdl" as TestTask
+
+workflow HelloWorld {
+    input {
+        String name
+    }
+    call TestTask.WriteGreeting {
+        input:
+            name = name
+    }
+}
+

--- a/dockstore-client/src/test/resources/wfAndCallOnly.wdl
+++ b/dockstore-client/src/test/resources/wfAndCallOnly.wdl
@@ -1,0 +1,3 @@
+workflow test {
+    call hello
+}


### PR DESCRIPTION
**Description**
Currently, the `CLI` does not accept WDL workflows that do not contain `task`, `command`, or `output` in the `--entry` file. However, it is possible to have a valid WDL workflow that does not contain these fields, through the use of [sub-workflows](https://cromwell.readthedocs.io/en/stable/SubWorkflows/), an example given [here](https://github.com/openwdl/learn-wdl/tree/master/1_script_examples/1_hello_worlds/7_subworkflow).

To fix this, I have modified the method `WDLClient.check(file)` such that it only sends an error message if either `workflow` or `call` are not found in the `--entry` file and it gives a warning to the user if the `--entry` is missing `task`, `command`, or `output`.

I am giving the warning as if the WDL is invalid, when it is launched, it will give the user a lot of error messages, but many of them are confusing, particularly if it is for a simple mistake such as forgetting to specify a `task`.

The warning message looks like this, `WARNING: these fields are missing from WDL file, this could be causing errors: 'task' 'command' 'output''`.


*The method `WDLClient.check(file)` is not necessarily required, as if the files are invalid, error messages will be given when the tool is launched, but these messages can be very confusing.

**Review Instructions**
Ensure that workflows such as the one specified in this [discourse discussion](https://discuss.dockstore.org/t/the-dockstore-tool-launch-wrongly-complains-missing-task-and-command/5874) are able to be run on the `dockstore-cli`.

This feature can be checked with `dockstore tool launch --entry [FILE PATH] --json [JSON PATH]`.

**Issue**
[DOCK-2245](https://ucsc-cgl.atlassian.net/browse/DOCK-2245)
https://github.com/dockstore/dockstore/issues/5133

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [X] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [X] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.


[DOCK-2245]: https://ucsc-cgl.atlassian.net/browse/DOCK-2245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ