### PR TITLE
CLI Using Beta TRS API - SEAB-5206

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -53,6 +53,7 @@ import io.dockstore.common.GeneratedConstants;
 import io.dockstore.common.Utilities;
 import io.dockstore.common.WdlBridgeShutDown;
 import io.dockstore.openapi.client.api.Ga4Ghv20Api;
+import io.dockstore.openapi.client.model.TRSService;
 import io.github.collaboratory.cwl.cwlrunner.CWLRunnerFactory;
 import io.github.collaboratory.cwl.cwlrunner.CWLRunnerInterface;
 import io.swagger.client.ApiClient;
@@ -61,12 +62,10 @@ import io.swagger.client.Configuration;
 import io.swagger.client.api.ContainersApi;
 import io.swagger.client.api.ContainertagsApi;
 import io.swagger.client.api.ExtendedGa4GhApi;
-import io.swagger.client.api.Ga4GhApi;
 import io.swagger.client.api.MetadataApi;
 import io.swagger.client.api.UsersApi;
 import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.auth.ApiKeyAuth;
-import io.swagger.client.model.Metadata;
 import org.apache.commons.configuration2.INIConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -132,7 +131,6 @@ public class Client {
     private static final Logger LOG = LoggerFactory.getLogger(Client.class);
     private String configFile = null;
     private String serverUrl = null;
-    private Ga4GhApi ga4ghApi;
     private Ga4Ghv20Api ga4ghv20Api;
     private ExtendedGa4GhApi extendedGA4GHApi;
     private MetadataApi metadataApi;
@@ -660,9 +658,9 @@ public class Client {
      */
     private void serverMetadata() {
         try {
-            final Metadata metadata = ga4ghApi.metadataGet();
+            final TRSService serviceinfo = ga4ghv20Api.getServiceInfo();
             final Gson gson = io.cwl.avro.CWL.getTypeSafeCWLToolDocument();
-            out(gson.toJson(metadata));
+            out(gson.toJson(serviceinfo));
             out("Dockstore server: " + serverUrl);
         } catch (ApiException ex) {
             exceptionMessage(ex, "", API_ERROR);
@@ -842,7 +840,6 @@ public class Client {
 
         ContainersApi containersApi = new ContainersApi(defaultApiClient);
         UsersApi usersApi = new UsersApi(defaultApiClient);
-        this.ga4ghApi = new Ga4GhApi(defaultApiClient);
         this.extendedGA4GHApi = new ExtendedGa4GhApi(defaultApiClient);
         this.metadataApi = new MetadataApi(defaultApiClient);
 


### PR DESCRIPTION
**Description**
Spin off ticket from DOCK-2300 (UI Relying on Beta TRS) this ticket switches from using `TRS 2.0.0-beta.2` API to `TRS 2.0.0` in the CLI. Appears to only be used in the `serverMetadata()` function, like in the UI, switched from using the `/api/ga4gh/v2/metadata` call to `/ga4gh/trs/v2/service-info`.

Output from `--server-metadata` before:
```
{
  "apiVersion": "2.0.0",
  "country": "CAN",
  "friendlyName": "Dockstore",
  "version": "1.13.1"
}
Dockstore server: https://dockstore.org/api
```
Output from `--server-metadata` after:
```
{
  "contactUrl": "https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506",
  "createdAt": "Jul 1, 2020, 8:00:00 PM",
  "description": "Dockstore is an implementation of the GA4GH Tool Registry API which is a standard for listing and describing available tools (both stand-alone, Docker-based tools as well as workflows in CWL, WDL, Nextflow, or Galaxy)",
  "documentationUrl": "https://docs.dockstore.org",
  "environment": "prod",
  "id": "1",
  "name": "Dockstore",
  "organization": {
    "name": "Dockstore",
    "url": "https://dockstore.org"
  },
  "type": {
    "artifact": "TRS",
    "group": "org.ga4gh",
    "version": "2.0.1"
  },
  "updatedAt": "Feb 3, 2023, 3:20:42 PM",
  "version": "1.13.1"
}
Dockstore server: https://dockstore.org/api
```

**Review Instructions**


**Issue**
SEAB-5206

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
