### PR TITLE
Corrected Typos found in CLI

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -158,7 +158,7 @@
     <module name="TreeWalker">
         <property name="tabWidth" value="4"/>
 
-        <!-- Checks identation.                               -->
+        <!-- Checks indentation.                               -->
         <module name="Indentation">
             <!-- Dockstore override, 2 to 4 -->
             <property name="basicOffset" value="4"/>

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
@@ -201,7 +201,7 @@ class ClientIT extends BaseIT {
      Since the below containers use dummy data and don't connect with Github/Bitbucket/Quay, the refresh will throw an error.
      Todo: Set up these tests with real data (not confidential)
      */
-    @Disabled("Since dockstore now checks for associated tags for Quay container, manual publishing of nonexistant images won't work")
+    @Disabled("Since dockstore now checks for associated tags for Quay container, manual publishing of nonexistent images won't work")
     void manualRegisterABunchOfValidEntries() throws IOException {
         Client.main(new String[] { CONFIG, TestUtility.getConfigFileLocation(true), TOOL, MANUAL_PUBLISH, "--registry",
             Registry.QUAY_IO.toString(), "--namespace", "pypi", "--name", "bd2k-python-lib", "--git-url",
@@ -508,9 +508,9 @@ class ClientIT extends BaseIT {
      * @param commandToBeTested A command that is valid, but will be modified to become invalid by this method
      */
     private void checkSuggestionIsGiven(String[] validCommands, String commandToBeTested) throws IOException {
-        String formmatedValidCommandString = join(" ", validCommands);
-        if (!formmatedValidCommandString.isBlank()) {
-            formmatedValidCommandString = " " + formmatedValidCommandString;
+        String formattedValidCommandString = join(" ", validCommands);
+        if (!formattedValidCommandString.isBlank()) {
+            formattedValidCommandString = " " + formattedValidCommandString;
         }
 
         final List<String> commandsForCapitalizationTest = Lists.newArrayList(validCommands);
@@ -520,8 +520,8 @@ class ClientIT extends BaseIT {
 
         systemOutRule.clear();
         Client.main(commandsForCapitalizationTest.toArray(new String[0]));
-        assertTrue(systemOutRule.getText().contains("dockstore" + formmatedValidCommandString + ": '" + commandToBeTested.toUpperCase()
-                        + "' is not a dockstore command. See 'dockstore" + formmatedValidCommandString + " " + HELP
+        assertTrue(systemOutRule.getText().contains("dockstore" + formattedValidCommandString + ": '" + commandToBeTested.toUpperCase()
+                        + "' is not a dockstore command. See 'dockstore" + formattedValidCommandString + " " + HELP
                         + "'.\n\n" + "The most similar command is:\n    " + commandToBeTested + "\n"));
 
         systemOutRule.clear();
@@ -538,8 +538,8 @@ class ClientIT extends BaseIT {
         commandsForLetterChangeTest.add(CONFIG);
         commandsForLetterChangeTest.add(TestUtility.getConfigFileLocation(true));
         Client.main(commandsForLetterChangeTest.toArray(new String[0]));
-        assertTrue(systemOutRule.getText().contains("dockstore" + formmatedValidCommandString + ": '" + commandWithLetterChanged
-                        + "' is not a dockstore command. See 'dockstore" + formmatedValidCommandString + " " + HELP
+        assertTrue(systemOutRule.getText().contains("dockstore" + formattedValidCommandString + ": '" + commandWithLetterChanged
+                        + "' is not a dockstore command. See 'dockstore" + formattedValidCommandString + " " + HELP
                         + "'.\n\n" + "The most similar command is:\n    " + commandToBeTested + "\n"));
 
     }

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/CromwellIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/CromwellIT.java
@@ -129,7 +129,7 @@ class CromwellIT {
         // run a workflow
         final long run = wdlClient.launch(workflowFile.getAbsolutePath(), true, null, newJsonPath, tempDir.getAbsolutePath(), null);
         assertEquals(0, run);
-        // let's check that provisioning out occured
+        // let's check that provisioning out occurred
         final Collection<File> files = FileUtils.listFiles(tempDir, null, true);
         assertEquals(2, files.size());
     }

--- a/dockstore-cli-integration-testing/src/test/resources/hosted_metadata/Dockstore.cwl
+++ b/dockstore-cli-integration-testing/src/test/resources/hosted_metadata/Dockstore.cwl
@@ -31,7 +31,7 @@ inputs:
   - id: reverse_sort
     type: boolean
     default: true
-    description: "If true, reverse (decending) sort"
+    description: "If true, reverse (descending) sort"
 
 # The "outputs" array defines the structure of the output object that describes
 # the outputs of the workflow.

--- a/dockstore-cli-integration-testing/src/test/resources/hosted_metadata/sorttool.cwl
+++ b/dockstore-cli-integration-testing/src/test/resources/hosted_metadata/sorttool.cwl
@@ -6,7 +6,7 @@ cwlVersion: v1.0
 
 # This example is similar to the previous one, with an additional input
 # parameter called "reverse".  It is a boolean parameter, which is
-# intepreted as a command line flag.  The value of "prefix" is used for
+# interpreted as a command line flag.  The value of "prefix" is used for
 # flag to put on the command line if "reverse" is true, if "reverse" is
 # false, no flag is added.
 #

--- a/dockstore-client/README.md
+++ b/dockstore-client/README.md
@@ -77,7 +77,7 @@ To run the Launcher:
 
     export AWS_ACCESS_KEY=AAAAAAA
     export AWS_SECRET_KEY=SSSSSSS
-    java -cp <launcher.jar> io.github.collaboratory.LauncherCWL --config <path_to_launcher.config> --decriptor <path_to_json_descriptor>
+    java -cp <launcher.jar> io.github.collaboratory.LauncherCWL --config <path_to_launcher.config> --descriptor <path_to_json_descriptor>
 
     # for example:
     java -cp launcher/target/uber-io.github.collaboratory.launcher-1.0.2-SNAPSHOT.jar io.github.collaboratory.LauncherCWL --config launcher.ini --descriptor collab.cwl --job collab-cwl-job-pre.json

--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -397,7 +397,7 @@
                         </goals>
                         <configuration>
                             <transformers>
-                                <!-- Akka used by Cromwell expects a consistant reference.conf file.  Also order matters, so keep it first in the list of transformers -->
+                                <!-- Akka used by Cromwell expects a consistent reference.conf file.  Also order matters, so keep it first in the list of transformers -->
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                     <resource>reference.conf</resource>
                                 </transformer>

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/JCommanderUtility.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/JCommanderUtility.java
@@ -71,7 +71,7 @@ public final class JCommanderUtility {
     }
 
     // TODO: Find a better way to determine if Jcommander.parse failed due to an incorrect parameter being given
-    public static boolean wasErrorDueToUnknownParamter(String errorMsg) {
+    public static boolean wasErrorDueToUnknownParameter(String errorMsg) {
         return errorMsg.contains("but no main parameter was defined in your arg class");
     }
 

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/PluginClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/PluginClient.java
@@ -43,7 +43,7 @@ import static io.dockstore.client.cli.Client.PLUGIN;
 import static io.dockstore.client.cli.JCommanderUtility.displayJCommanderSuggestions;
 import static io.dockstore.client.cli.JCommanderUtility.getUnknownParameter;
 import static io.dockstore.client.cli.JCommanderUtility.printJCommanderHelp;
-import static io.dockstore.client.cli.JCommanderUtility.wasErrorDueToUnknownParamter;
+import static io.dockstore.client.cli.JCommanderUtility.wasErrorDueToUnknownParameter;
 import static io.dockstore.client.cli.nested.AbstractEntryClient.LIST;
 import static java.lang.String.join;
 
@@ -101,7 +101,7 @@ public final class PluginClient {
         } catch (MissingCommandException e) {
             displayJCommanderSuggestions(jcPlugin, e.getJCommander().getParsedCommand(), args.get(0), PLUGIN);
         } catch (ParameterException e) {
-            if (wasErrorDueToUnknownParamter(e.getMessage())) {
+            if (wasErrorDueToUnknownParameter(e.getMessage())) {
                 String incorrectCommand = getUnknownParameter(e.getMessage());
                 displayJCommanderSuggestions(jcPlugin, e.getJCommander().getParsedCommand(), incorrectCommand, join(" ", PLUGIN, e.getJCommander().getParsedCommand()));
             } else {

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/YamlVerifyUtility.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/YamlVerifyUtility.java
@@ -36,7 +36,7 @@ import static io.dockstore.client.cli.ArgumentUtility.out;
 
 /*
     GENERAL STEPS:
-    1. Verfiy that YAML syntax is valid
+    1. Verify that YAML syntax is valid
     2. Verify that all fields are named correctly
     3. Verify that all required fields are present
     4. Verify that all files exist

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -129,7 +129,7 @@ import static io.dockstore.client.cli.Client.WORKFLOW;
 import static io.dockstore.client.cli.Client.getGeneralFlags;
 import static io.dockstore.client.cli.JCommanderUtility.displayJCommanderSuggestions;
 import static io.dockstore.client.cli.JCommanderUtility.getUnknownParameter;
-import static io.dockstore.client.cli.JCommanderUtility.wasErrorDueToUnknownParamter;
+import static io.dockstore.client.cli.JCommanderUtility.wasErrorDueToUnknownParameter;
 import static io.dockstore.client.cli.YamlVerifyUtility.YAML;
 import static io.dockstore.client.cli.nested.WesCommandParser.ATTACH;
 import static io.dockstore.client.cli.nested.WesCommandParser.COUNT;
@@ -154,7 +154,7 @@ import static java.lang.String.join;
  * implementing classes that do not need to reference to the command line arguments directly.
  * <p>
  * Note that many of these methods depend on a unique identifier for an entry called a path for workflows and tools.
- * For example, a tool path looks like quay.io/collaboratory/bwa-tool:develop wheras a workflow path looks like
+ * For example, a tool path looks like quay.io/collaboratory/bwa-tool:develop whereas a workflow path looks like
  * collaboratory/bwa-workflow:develop
  *
  * @author dyuen
@@ -255,7 +255,7 @@ public abstract class AbstractEntryClient<T> {
         out("  " + LIST + "             :  lists all the " + getEntryType() + "s published by the user");
         out("");
         if (WORKFLOW.equalsIgnoreCase(getEntryType())) {
-            out("  " + NFL + "              :  returns the Nextflow " + getEntryType() + " defintion for this entry");
+            out("  " + NFL + "              :  returns the Nextflow " + getEntryType() + " definition for this entry");
             out("");
         }
         out("  " + PUBLISH + "          :  publish/unpublish a " + getEntryType() + " in Dockstore");
@@ -389,7 +389,7 @@ public abstract class AbstractEntryClient<T> {
     /**
      * Handle search for an entry
      *
-     * @param pattern a pattern, currently a subtring for searching
+     * @param pattern a pattern, currently a substring for searching
      */
     protected abstract void handleSearch(String pattern);
 
@@ -1132,7 +1132,7 @@ public abstract class AbstractEntryClient<T> {
     /**
      * Attempts to launch a workflow (tools not currently supported) on a WES server
      * @param clientWorkflowExecutionServiceApi The WES API client
-     * @param entry The path to the desired entry (i.e. github.com/myrepo/myworfklow:version1
+     * @param entry The path to the desired entry (i.e. github.com/myrepo/myworkflow:version1
      * @param inlineWorkflow Indicates that the workflow files will be inlined directly into the WES HTTP request
      * @param paramsPath Path to the parameter JSON file
      * @param filePaths Paths to any other required files for the WES execution
@@ -1279,7 +1279,7 @@ public abstract class AbstractEntryClient<T> {
             displayJCommanderSuggestions(wesCommandParser.jCommander, e.getJCommander().getParsedCommand(), args.get(0), WORKFLOW + " " + WES);
             return;
         } catch (ParameterException e) {
-            if (wasErrorDueToUnknownParamter(e.getMessage())) {
+            if (wasErrorDueToUnknownParameter(e.getMessage())) {
                 // This is for when JCommander parse understands part of the command. This is for incorrect commands of the form:
                 // dockstore workflow CORRECT_COMMAND INCORRECT_COMMAND
                 String incorrectCommand = getUnknownParameter(e.getMessage());

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/BaseLanguageClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/BaseLanguageClient.java
@@ -166,7 +166,7 @@ public abstract class BaseLanguageClient {
 
         /*
          Don't download the input files (from the input JSON or YAML) if we are making a request
-         to a WES endpoint. We want the WES endpoint to download the input files becuase they
+         to a WES endpoint. We want the WES endpoint to download the input files because they
          could be very large and in that case we cannot send their contents in a POST request
          efficiently.
          TODO if there are input files on the local file system maybe we should send those to

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/DepCommand.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/DepCommand.java
@@ -19,7 +19,7 @@ import static io.dockstore.client.cli.Client.DEPS;
 import static io.dockstore.client.cli.Client.HELP;
 import static io.dockstore.client.cli.JCommanderUtility.displayJCommanderSuggestions;
 import static io.dockstore.client.cli.JCommanderUtility.getUnknownParameter;
-import static io.dockstore.client.cli.JCommanderUtility.wasErrorDueToUnknownParamter;
+import static io.dockstore.client.cli.JCommanderUtility.wasErrorDueToUnknownParameter;
 
 /**
  * @author gluu
@@ -48,7 +48,7 @@ public final class DepCommand {
             displayJCommanderSuggestions(jCommanderMain, e.getJCommander().getParsedCommand(), args[0], DEPS);
             return true;
         } catch (ParameterException e) {
-            if (wasErrorDueToUnknownParamter(e.getMessage())) {
+            if (wasErrorDueToUnknownParameter(e.getMessage())) {
                 String incorrectCommand = getUnknownParameter(e.getMessage());
                 displayJCommanderSuggestions(jCommanderMain, e.getJCommander().getParsedCommand(), incorrectCommand, DEPS);
             } else {

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
@@ -1161,7 +1161,7 @@ public class ToolClient extends AbstractEntryClient<DockstoreTool> {
     /**
      * Does nothing currently, as tools are not supported in WES
      * @param clientWorkflowExecutionServiceApi The WES API client
-     * @param entry The path to the desired entry (i.e. github.com/myrepo/myworfklow:version1
+     * @param entry The path to the desired entry (i.e. github.com/myrepo/myworkflow:version1
      * @param inlineWorkflow Indicates that the workflow files will be inlined directly into the WES HTTP request
      * @param paramsPath Path to the parameter JSON file
      * @param filePaths Paths to any other required files for the WES execution

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -515,7 +515,7 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
     /**
      * Attempts to launch a workflow on a WES server
      * @param clientWorkflowExecutionServiceApi The WES API client
-     * @param entry The path to the desired entry (i.e. github.com/myrepo/myworfklow:version1
+     * @param entry The path to the desired entry (i.e. github.com/myrepo/myworkflow:version1
      * @param inlineWorkflow Indicates that the workflow files will be inlined directly into the WES HTTP request
      * @param paramsPath Path to the parameter JSON file
      * @param filePaths Paths to any other required files for the WES execution

--- a/dockstore-client/src/main/java/io/github/collaboratory/cwl/CWLClient.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/cwl/CWLClient.java
@@ -713,7 +713,7 @@ public class CWLClient extends BaseLanguageClient implements LanguageClientInter
     }
 
     /**
-     * Scours a CWL document paired with a JSON document to create our data structure for describing desired output files (for provisoning)
+     * Scours a CWL document paired with a JSON document to create our data structure for describing desired output files (for provisioning)
      *
      * @param cwl           deserialized CWL document
      * @param inputsOutputs inputs and output from json document

--- a/dockstore-client/src/test/resources/topmed_freeze3_calling.wdl
+++ b/dockstore-client/src/test/resources/topmed_freeze3_calling.wdl
@@ -651,7 +651,7 @@ workflow TopMedVariantCaller {
       # The resulting string will be empty if the contamination values
       # are not calculated
       contamination_output_file_names_string = "${ sep=',' contamination_output_files }"
-      # If DNA contaminiation was calculated for input files (CRAMs)
+      # If DNA contamination was calculated for input files (CRAMs)
       if len(contamination_output_file_names_string) > 0:
           contamination_output_file_names_list = contamination_output_file_names_string.split(',')
           print("variantCalling: Contamination output files list is {}".format(contamination_output_file_names_list))
@@ -673,7 +673,7 @@ workflow TopMedVariantCaller {
               # Get the Cromwell basename  of the CRAM file
               # The worklow will be able to access them
               # since the Cromwell path is mounted in the
-              # docker run commmand that Cromwell sets up
+              # docker run command that Cromwell sets up
               base_name = os.path.basename(cram_file)
               base_name_wo_extension = base_name.split('.')[0]
 
@@ -699,7 +699,7 @@ workflow TopMedVariantCaller {
               # Get the Cromwell basename  of the CRAM file
               # The worklow will be able to access them
               # since the Cromwell path is mounted in the
-              # docker run commmand that Cromwell sets up
+              # docker run command that Cromwell sets up
               base_name = os.path.basename(cram_file)
               base_name_wo_extension = base_name.split('.')[0]
  

--- a/dockstore-file-plugin-parent/README.md
+++ b/dockstore-file-plugin-parent/README.md
@@ -87,8 +87,7 @@ Calling on plugin io.dockstore.provision.S3Plugin$S3Provision to provision s3://
 Calling out to cwltool to run your tool
 Executing: cwltool --enable-dev --non-strict --outdir /media/large_volume/dockstore_tools/dockstore-tool-md5sum/./datastore/launcher-a246f1b6-21fd-468e-8780-b064d311dda5/outputs/ --tmpdir-prefix /media/large_volu
 me/dockstore_tools/dockstore-tool-md5sum/./datastore/launcher-a246f1b6-21fd-468e-8780-b064d311dda5/tmp/ --tmp-outdir-prefix /media/large_volume/dockstore_tools/dockstore-tool-md5sum/./datastore/launcher-a246f1b6-
-21fd-468e-8780-b064d311dda5/working/ /tmp/1488407859906-0/temp3047430238970788171.cwl /media/large_volume/dockstore_tools/dockstore-tool-md5sum/./datastore/launcher-a246f1b6-21fd-468e-8780-b064d311dda5/workflow_p
-arams.json
+21fd-468e-8780-b064d311dda5/working/ /tmp/1488407859906-0/temp3047430238970788171.cwl /media/large_volume/dockstore_tools/dockstore-tool-md5sum/./datastore/launcher-a246f1b6-21fd-468e-8780-b064d311dda5/workflow_params.json
 /usr/local/bin/cwltool 1.0.20170217172322
 ...
 ```

--- a/dockstore-file-plugin-parent/src/main/java/io/dockstore/provision/ProgressPrinter.java
+++ b/dockstore-file-plugin-parent/src/main/java/io/dockstore/provision/ProgressPrinter.java
@@ -23,7 +23,7 @@ import java.math.RoundingMode;
 import org.apache.commons.lang3.StringUtils;
 
 /**
- * A printer of the progress for file provisoning plugins.
+ * A printer of the progress for file provisioning plugins.
  *
  * @author dyuen
  */
@@ -63,7 +63,7 @@ public class ProgressPrinter {
 
         if (streamSize <= 0) { // Unknown size
             if (System.console() != null) {
-                System.out.print(generateIntedeteminateBar());
+                System.out.print(generateIndeterminateBar());
 
                 if (spinnerAscending) {
                     spinnerIndex++;
@@ -130,7 +130,7 @@ public class ProgressPrinter {
         }
     }
 
-    private String generateIntedeteminateBar() {
+    private String generateIndeterminateBar() {
         final StringBuilder sb = new StringBuilder("\r[");
         if (spinnerIndex < INDETERMINATE_INDICATOR.length()) {
             sb.append(INDETERMINATE_INDICATOR);

--- a/openapi-java-wes-client/src/main/resources/OPENAPI_CREATION.md
+++ b/openapi-java-wes-client/src/main/resources/OPENAPI_CREATION.md
@@ -15,5 +15,5 @@ https://raw.githubusercontent.com/ga4gh/workflow-execution-service-schemas/1.0.0
 1. Click on the green box with the down arrow at the top right of the editor
 1. Select 'Convert to OpenAPI 3.0'
 1. In the 'Convert to OpenAPI 3.0?' dialog click 'Convert & Update'
-1. Click the 'Export' button on the uppper right hand area of the page
+1. Click the 'Export' button on the upper right hand area of the page
 1. Select '< Download API' and then 'YAML Unresolved' ..The yaml file will be downloaded to your local machine

--- a/pom.xml
+++ b/pom.xml
@@ -379,7 +379,7 @@
                             </goals>
                             <configuration>
                                 <transformers>
-                                    <!-- Akka used by Cromwell expects a consistant reference.conf file.  Also order matters, so keep it first in the list of transformers -->
+                                    <!-- Akka used by Cromwell expects a consistent reference.conf file.  Also order matters, so keep it first in the list of transformers -->
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                         <resource>reference.conf</resource>
                                     </transformer>


### PR DESCRIPTION
**Description**
This PR corrects a few typos in the CLI.

Whilst going in to fix the typo that @coverbeck  spotted in the CLI, I noticed a few others. 

To find all of the typos in this PR I used cspell. Specifically this command (more info [here](https://cspell.org/docs/getting-started/))
```
cspell --words-only --unique "**" | sort --ignore-case >> project-words.txt
```
which was helpful, as it gave me a list of all the words that it had found to be misspelled in the CLI, and then I just wen through and searched for the ones that were actually misspelled and corrected them. This process took about 15 minutes, so if you like I could do this to https://github.com/dockstore/dockstore and https://github.com/dockstore/dockstore-ui2 fairly quickly.

**Review Instructions**

- Ensure that all of my corrections are valid (ie. I didn't replace a typo with a typo)

**Issue**
[DOCK-2325](https://ucsc-cgl.atlassian.net/browse/DOCK-2325)
https://github.com/dockstore/dockstore/issues/5365

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.


[DOCK-2325]: https://ucsc-cgl.atlassian.net/browse/DOCK-2325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ