### PR TITLE
Fix Incorrect Help Page and made tests around help pages more robust

### DIFF
--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
@@ -466,10 +466,10 @@ class ClientIT extends BaseIT {
         strings.add(TestUtility.getConfigFileLocation(true));
 
         Client.main(strings.toArray(new String[0]));
-        assertTrue(systemOutRule.getText().contains("Usage: dockstore"), "'Usage: dockstore' isn't being displayed, this probably means" +
-                "that no help page is being shown");
-        assertTrue(systemOutRule.getText().contains("dockstore " + join(" ", argv)), "`Usage: dockstore` is being displayed" +
-                "but it does not contain the strings found in argv, this probably means the wrong help page is being displayed");
+        assertTrue(systemOutRule.getText().contains("Usage: dockstore"), "'Usage: dockstore' isn't being displayed, this probably means"
+                + "that no help page is being shown");
+        assertTrue(systemOutRule.getText().contains("dockstore " + join(" ", argv)), "`Usage: dockstore` is being displayed"
+                + "but it does not contain the strings found in argv, this probably means the wrong help page is being displayed");
         systemOutRule.clear();
     }
 

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
@@ -347,112 +347,129 @@ class ClientIT extends BaseIT {
     @Test
     void touchOnAllHelpMessages() throws IOException {
 
-        checkCommandForHelp(new String[] { TOOL, SEARCH });
-        checkCommandForHelp(new String[] { TOOL, INFO });
-        checkCommandForHelp(new String[] { TOOL, "cwl" });
-        checkCommandForHelp(new String[] { TOOL, "wdl" });
-        checkCommandForHelp(new String[] { TOOL, LABEL });
-        checkCommandForHelp(new String[] { TOOL, TEST_PARAMETER });
-        checkCommandForHelp(new String[] { TOOL, CONVERT });
-        checkCommandForHelp(new String[] { TOOL, LAUNCH });
-        checkCommandForHelp(new String[] { TOOL, VERSION_TAG });
-        checkCommandForHelp(new String[] { TOOL, UPDATE_TOOL });
+        checkCommandForHelp(new String[] { TOOL, SEARCH }, false);
+        checkCommandForHelp(new String[] { TOOL, INFO }, false);
+        checkCommandForHelp(new String[] { TOOL, "CWL" }, false);
+        checkCommandForHelp(new String[] { TOOL, "WDL" }, false);
+        checkCommandForHelp(new String[] { TOOL, LABEL }, false);
+        checkCommandForHelp(new String[] { TOOL, TEST_PARAMETER }, false);
+        checkCommandForHelp(new String[] { TOOL, CONVERT }, false);
+        checkCommandForHelp(new String[] { TOOL, LAUNCH }, false);
+        checkCommandForHelp(new String[] { TOOL, VERSION_TAG }, false);
+        checkCommandForHelp(new String[] { TOOL, UPDATE_TOOL }, false);
 
-        checkCommandForHelp(new String[] { TOOL, CONVERT, ENTRY_2_JSON });
-        checkCommandForHelp(new String[] { TOOL, CONVERT, CWL_2_YAML });
-        checkCommandForHelp(new String[] { TOOL, CONVERT, CWL_2_JSON });
-        checkCommandForHelp(new String[] { TOOL, CONVERT, WDL_2_JSON });
+        checkCommandForHelp(new String[] { TOOL, CONVERT, ENTRY_2_JSON }, false);
+        checkCommandForHelp(new String[] { TOOL, CONVERT, CWL_2_YAML }, false);
+        checkCommandForHelp(new String[] { TOOL, CONVERT, CWL_2_JSON }, false);
+        checkCommandForHelp(new String[] { TOOL, CONVERT, WDL_2_JSON }, false);
 
-        checkCommandForHelp(new String[] {});
-        checkCommandForHelp(new String[] { TOOL });
-        checkCommandForHelp(new String[] { TOOL, DOWNLOAD, HELP });
-        checkCommandForHelp(new String[] { TOOL, LIST, HELP });
-        checkCommandForHelp(new String[] { TOOL, SEARCH, HELP });
-        checkCommandForHelp(new String[] { TOOL, PUBLISH, HELP });
-        checkCommandForHelp(new String[] { TOOL, INFO, HELP });
-        checkCommandForHelp(new String[] { TOOL, "cwl", HELP });
-        checkCommandForHelp(new String[] { TOOL, "wdl", HELP });
-        checkCommandForHelp(new String[] { TOOL, REFRESH, HELP });
-        checkCommandForHelp(new String[] { TOOL, LABEL, HELP });
-        checkCommandForHelp(new String[] { TOOL, CONVERT, HELP });
-        checkCommandForHelp(new String[] { TOOL, CONVERT, CWL_2_JSON, HELP });
-        checkCommandForHelp(new String[] { TOOL, CONVERT, CWL_2_YAML, HELP });
-        checkCommandForHelp(new String[] { TOOL, CONVERT, WDL_2_JSON, HELP });
-        checkCommandForHelp(new String[] { TOOL, CONVERT, ENTRY_2_JSON, HELP });
-        checkCommandForHelp(new String[] { TOOL, LAUNCH, HELP });
-        checkCommandForHelp(new String[] { TOOL, VERSION_TAG, HELP });
-        checkCommandForHelp(new String[] { TOOL, VERSION_TAG, "remove", HELP });
-        checkCommandForHelp(new String[] { TOOL, VERSION_TAG, UPDATE, HELP });
-        checkCommandForHelp(new String[] { TOOL, VERSION_TAG, ADD, HELP });
-        checkCommandForHelp(new String[] { TOOL, UPDATE_TOOL, HELP });
-        checkCommandForHelp(new String[] { TOOL, MANUAL_PUBLISH, HELP });
-        checkCommandForHelp(new String[] { TOOL, STAR, HELP });
-        checkCommandForHelp(new String[] { TOOL, TEST_PARAMETER, HELP });
-        checkCommandForHelp(new String[] { TOOL, VERIFY, HELP });
-        checkCommandForHelp(new String[] { TOOL });
+        checkCommandForHelp(new String[] {}, false);
+        checkCommandForHelp(new String[] { TOOL }, false);
+        checkCommandForHelp(new String[] { TOOL, DOWNLOAD }, true);
+        checkCommandForHelp(new String[] { TOOL, LIST }, true);
+        checkCommandForHelp(new String[] { TOOL, SEARCH }, true);
+        checkCommandForHelp(new String[] { TOOL, PUBLISH }, true);
+        checkCommandForHelp(new String[] { TOOL, INFO }, true);
+        checkCommandForHelp(new String[] { TOOL, "CWL" }, true);
+        checkCommandForHelp(new String[] { TOOL, "WDL" }, true);
+        checkCommandForHelp(new String[] { TOOL, REFRESH }, true);
+        checkCommandForHelp(new String[] { TOOL, LABEL }, true);
+        checkCommandForHelp(new String[] { TOOL, CONVERT }, true);
+        checkCommandForHelp(new String[] { TOOL, CONVERT, CWL_2_JSON }, true);
+        checkCommandForHelp(new String[] { TOOL, CONVERT, CWL_2_YAML }, true);
+        checkCommandForHelp(new String[] { TOOL, CONVERT, WDL_2_JSON }, true);
+        checkCommandForHelp(new String[] { TOOL, CONVERT, ENTRY_2_JSON }, true);
+        checkCommandForHelp(new String[] { TOOL, LAUNCH }, true);
+        checkCommandForHelp(new String[] { TOOL, VERSION_TAG }, true);
+        checkCommandForHelp(new String[] { TOOL, VERSION_TAG, "remove" }, true);
+        checkCommandForHelp(new String[] { TOOL, VERSION_TAG, UPDATE }, true);
+        checkCommandForHelp(new String[] { TOOL, VERSION_TAG, ADD }, true);
+        checkCommandForHelp(new String[] { TOOL, UPDATE_TOOL }, true);
+        checkCommandForHelp(new String[] { TOOL, MANUAL_PUBLISH }, true);
+        checkCommandForHelp(new String[] { TOOL, STAR }, true);
+        checkCommandForHelp(new String[] { TOOL, TEST_PARAMETER }, true);
+        checkCommandForHelp(new String[] { TOOL, VERIFY }, true);
+        checkCommandForHelp(new String[] { TOOL }, false);
 
-        checkCommandForHelp(new String[] { WORKFLOW, CONVERT, ENTRY_2_JSON });
-        checkCommandForHelp(new String[] { WORKFLOW, CONVERT, CWL_2_YAML });
-        checkCommandForHelp(new String[] { WORKFLOW, CONVERT, CWL_2_JSON });
-        checkCommandForHelp(new String[] { WORKFLOW, CONVERT, WDL_2_JSON });
+        checkCommandForHelp(new String[] { WORKFLOW, CONVERT, ENTRY_2_JSON }, false);
+        checkCommandForHelp(new String[] { WORKFLOW, CONVERT, CWL_2_YAML }, false);
+        checkCommandForHelp(new String[] { WORKFLOW, CONVERT, CWL_2_JSON }, false);
+        checkCommandForHelp(new String[] { WORKFLOW, CONVERT, WDL_2_JSON }, false);
 
-        checkCommandForHelp(new String[] { WORKFLOW, SEARCH });
-        checkCommandForHelp(new String[] { WORKFLOW, INFO });
-        checkCommandForHelp(new String[] { WORKFLOW, "cwl" });
-        checkCommandForHelp(new String[] { WORKFLOW, "wdl" });
-        checkCommandForHelp(new String[] { WORKFLOW, LABEL });
-        checkCommandForHelp(new String[] { WORKFLOW, TEST_PARAMETER });
-        checkCommandForHelp(new String[] { WORKFLOW, CONVERT });
-        checkCommandForHelp(new String[] { WORKFLOW, LAUNCH });
-        checkCommandForHelp(new String[] { WORKFLOW, VERSION_TAG });
-        checkCommandForHelp(new String[] { WORKFLOW, UPDATE_WORKFLOW });
-        checkCommandForHelp(new String[] { WORKFLOW, "restub" });
+        checkCommandForHelp(new String[] { WORKFLOW, SEARCH }, false);
+        checkCommandForHelp(new String[] { WORKFLOW, INFO }, false);
+        checkCommandForHelp(new String[] { WORKFLOW, "CWL" }, false);
+        checkCommandForHelp(new String[] { WORKFLOW, "WDL" }, false);
+        checkCommandForHelp(new String[] { WORKFLOW, LABEL }, false);
+        checkCommandForHelp(new String[] { WORKFLOW, TEST_PARAMETER }, false);
+        checkCommandForHelp(new String[] { WORKFLOW, CONVERT }, false);
+        checkCommandForHelp(new String[] { WORKFLOW, LAUNCH }, false);
+        checkCommandForHelp(new String[] { WORKFLOW, VERSION_TAG }, false);
+        checkCommandForHelp(new String[] { WORKFLOW, UPDATE_WORKFLOW }, false);
+        checkCommandForHelp(new String[] { WORKFLOW, "restub" }, false);
 
-        checkCommandForHelp(new String[] { WORKFLOW, DOWNLOAD, HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, LIST, HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, SEARCH, HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, PUBLISH, HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, INFO, HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, "cwl", HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, "wdl", HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, REFRESH, HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, LABEL, HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, CONVERT, HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, CONVERT, CWL_2_JSON, HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, CONVERT, CWL_2_YAML, HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, CONVERT, "wd2json", HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, CONVERT, ENTRY_2_JSON, HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, LAUNCH, HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, VERSION_TAG, HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, UPDATE_WORKFLOW, HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, MANUAL_PUBLISH, HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, "restub", HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, STAR, HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, TEST_PARAMETER, HELP });
-        checkCommandForHelp(new String[] { WORKFLOW, VERIFY, HELP });
-        checkCommandForHelp(new String[] { WORKFLOW });
+        checkCommandForHelp(new String[] { WORKFLOW, DOWNLOAD }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, LIST }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, SEARCH }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, PUBLISH }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, INFO }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, "CWL" }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, "WDL" }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, REFRESH }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, LABEL }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, CONVERT }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, CONVERT, CWL_2_JSON }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, CONVERT, CWL_2_YAML }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, CONVERT, "wdl2json" }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, CONVERT, ENTRY_2_JSON }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, LAUNCH }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, VERSION_TAG }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, UPDATE_WORKFLOW }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, MANUAL_PUBLISH }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, "restub" }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, STAR }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, TEST_PARAMETER }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, VERIFY }, true);
+        checkCommandForHelp(new String[] { WORKFLOW }, false);
 
-        checkCommandForHelp(new String[] { PLUGIN, LIST, HELP });
-        checkCommandForHelp(new String[] { PLUGIN, DOWNLOAD, HELP });
-        checkCommandForHelp(new String[] { PLUGIN });
+        checkCommandForHelp(new String[] { PLUGIN, LIST }, true);
+        checkCommandForHelp(new String[] { PLUGIN, DOWNLOAD }, true);
+        checkCommandForHelp(new String[] { PLUGIN }, false);
 
-        checkCommandForHelp(new String[] { CHECKER });
-        checkCommandForHelp(new String[] { CHECKER, DOWNLOAD, HELP });
-        checkCommandForHelp(new String[] { CHECKER, LAUNCH, HELP });
-        checkCommandForHelp(new String[] { CHECKER, ADD, HELP });
-        checkCommandForHelp(new String[] { CHECKER, UPDATE, HELP });
-        checkCommandForHelp(new String[] { CHECKER, UPDATE_VERSION, HELP });
-        checkCommandForHelp(new String[] { CHECKER, TEST_PARAMETER, HELP });
+        checkCommandForHelp(new String[] { CHECKER }, false);
+        checkCommandForHelp(new String[] { CHECKER, DOWNLOAD }, true);
+        checkCommandForHelp(new String[] { CHECKER, LAUNCH }, true);
+        checkCommandForHelp(new String[] { CHECKER, ADD }, true);
+        checkCommandForHelp(new String[] { CHECKER, UPDATE }, true);
+        checkCommandForHelp(new String[] { CHECKER, UPDATE_VERSION }, true);
+        checkCommandForHelp(new String[] { CHECKER, TEST_PARAMETER }, true);
 
     }
 
-    private void checkCommandForHelp(String[] argv) throws IOException {
+    /**
+     * This method passes all the values in argv and --help if includeHelpFlag is true to Client.main and ensures
+     * that the output contains,
+     * 1) "Usage: dockstore", this ensures that some help page is being displayed
+     * 2) "dockstore" followed by the strings in argv, for example, if argv = {"test", "blue", "green"}, it would ensure
+     * that the output contained the string "dockstore test blue green"
+     *
+     * @param argv the arguments to pass to Client.main, do not pass "--help"
+     * @param includeHelpFlag If true, "--help" will be passed to Client.main after the arguments in argv
+     * @throws IOException
+     */
+    private void checkCommandForHelp(String[] argv, Boolean includeHelpFlag) throws IOException {
         final ArrayList<String> strings = Lists.newArrayList(argv);
+        if (includeHelpFlag) {
+            strings.add(HELP);
+        }
         strings.add(CONFIG);
         strings.add(TestUtility.getConfigFileLocation(true));
 
         Client.main(strings.toArray(new String[0]));
-        assertTrue(systemOutRule.getText().contains("Usage: dockstore"));
+        assertTrue(systemOutRule.getText().contains("Usage: dockstore"), "'Usage: dockstore' isn't being displayed, this probably means" +
+                "that no help page is being shown");
+        assertTrue(systemOutRule.getText().contains("dockstore " + join(" ", argv)), "`Usage: dockstore` is being displayed" +
+                "but it does not contain the strings found in argv, this probably means the wrong help page is being displayed");
         systemOutRule.clear();
     }
 

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
@@ -457,7 +457,7 @@ class ClientIT extends BaseIT {
      * @param includeHelpFlag If true, "--help" will be passed to Client.main after the arguments in argv
      * @throws IOException
      */
-    private void checkCommandForHelp(String[] argv, Boolean includeHelpFlag) throws IOException {
+    private void checkCommandForHelp(String[] argv, boolean includeHelpFlag) throws IOException {
         final ArrayList<String> strings = Lists.newArrayList(argv);
         if (includeHelpFlag) {
             strings.add(HELP);

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/CheckerClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/CheckerClient.java
@@ -366,23 +366,19 @@ public class CheckerClient extends WorkflowClient {
 
     private void updateVersionChecker(List<String> args) {
         if (containsHelpRequest(args) || args.isEmpty()) {
-            versionTagHelp();
+            updateVersionCheckerHelp();
         } else {
             // Retrieve arguments
             String entryPath = reqVal(args, ENTRY);
-
             // Get entry from path
             Entry entry = getEntryFromPath(entryPath);
-
             // Get checker workflow
             Workflow checkerWorkflow = getCheckerWorkflowFromEntry(entry, true);
-
             // Update version
             if (entry != null && checkerWorkflow != null) {
-                // Readd entry path to call, but with checker workflow
+                // Read entry path to call, but with checker workflow
                 args.add(ENTRY);
                 args.add(checkerWorkflow.getFullWorkflowPath());
-
                 // Call inherited test parameter function
                 versionTag(args);
             }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/PluginClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/PluginClient.java
@@ -82,14 +82,14 @@ public final class PluginClient {
                 switch (jcPlugin.getParsedCommand()) {
                 case LIST:
                     if (commandPluginList.help) {
-                        printJCommanderHelp(jc, "dockstore", PLUGIN);
+                        printJCommanderHelp(jcPlugin, "dockstore " + PLUGIN, LIST);
                     } else {
                         return handleList(configFile);
                     }
                     break;
                 case DOWNLOAD:
                     if (commandPluginDownload.help) {
-                        printJCommanderHelp(jc, "dockstore", PLUGIN);
+                        printJCommanderHelp(jcPlugin, "dockstore " + PLUGIN, DOWNLOAD);
                     } else {
                         return handleDownload(configFile);
                     }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -791,7 +791,7 @@ public abstract class AbstractEntryClient<T> {
             args.add(0, VERIFY);
             String[] argsArray = new String[args.size()];
             argsArray = args.toArray(argsArray);
-            Verify.handleVerifyCommand(argsArray);
+            Verify.handleVerifyCommand(argsArray, getEntryType().toLowerCase());
         } else {
             out("This command is only accessible to Admins.");
         }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/Verify.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/Verify.java
@@ -31,13 +31,13 @@ final class Verify {
      *
      * @param args The command line arguments
      */
-    static void handleVerifyCommand(String[] args) {
+    static void handleVerifyCommand(String[] args, String entryType) {
         VerifyCommand verifyCommand = new VerifyCommand();
         JCommander jCommanderMain = new JCommander();
         JCommanderUtility.addCommand(jCommanderMain, VERIFY, verifyCommand);
         jCommanderMain.parse(args);
         if (verifyCommand.help) {
-            JCommanderUtility.printJCommanderHelp(jCommanderMain, "dockstore", VERIFY);
+            JCommanderUtility.printJCommanderHelp(jCommanderMain, "dockstore " + entryType, VERIFY);
         } else {
             ApiClient defaultApiClient;
             defaultApiClient = Configuration.getDefaultApiClient();

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -211,7 +211,7 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
     private void printRequiredParametersForVersionTag() {
         out("Required Parameters:");
         out("  " + ENTRY + " <entry>                                      Complete " + getEntryType().toLowerCase()
-                + " path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
+                + " path in Dockstore (ex. github.com/DataBiosphere/topmed-workflows/UM_variant_caller_wdl)");
         out("  --name <name>                                        Name of the " + getEntryType().toLowerCase() + " version.");
         out("");
         out("Optional Parameters");

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -83,6 +83,8 @@ import static io.dockstore.client.cli.ArgumentUtility.printHelpFooter;
 import static io.dockstore.client.cli.ArgumentUtility.printHelpHeader;
 import static io.dockstore.client.cli.ArgumentUtility.printLineBreak;
 import static io.dockstore.client.cli.ArgumentUtility.reqVal;
+import static io.dockstore.client.cli.CheckerClient.UPDATE_VERSION;
+import static io.dockstore.client.cli.Client.CHECKER;
 import static io.dockstore.client.cli.Client.CLIENT_ERROR;
 import static io.dockstore.client.cli.Client.COMMAND_ERROR;
 import static io.dockstore.client.cli.Client.ENTRY_NOT_FOUND;
@@ -202,14 +204,29 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
         out("Description:");
         out("  Update certain fields for a given " + getEntryType().toLowerCase() + " version.");
         out("");
+        printRequiredParametersForVersionTag();
+        printHelpFooter();
+    }
+
+    private void printRequiredParametersForVersionTag() {
         out("Required Parameters:");
         out("  " + ENTRY + " <entry>                                      Complete " + getEntryType().toLowerCase()
-            + " path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
+                + " path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
         out("  --name <name>                                        Name of the " + getEntryType().toLowerCase() + " version.");
         out("");
         out("Optional Parameters");
         out("  --workflow-path <workflow-path>                      Path to " + getEntryType().toLowerCase() + " descriptor");
         out("  --hidden <true/false>                                Hide the tag from public viewing, default false");
+    }
+
+    protected void updateVersionCheckerHelp() {
+        printHelpHeader();
+        out(join(" ", "Usage: dockstore", getEntryType().toLowerCase(), UPDATE_VERSION, HELP));
+        out(join(" ", "       dockstore", getEntryType().toLowerCase(), UPDATE_VERSION, "[parameters]"));
+        out("");
+        out(join(" ", "Updates a specific version of an existing", CHECKER, WORKFLOW + "."));
+        out("");
+        printRequiredParametersForVersionTag();
         printHelpFooter();
     }
 


### PR DESCRIPTION
**Description**
This PR does two things,

**1:**

It modifies this testing method,
https://github.com/dockstore/dockstore-cli/blob/411f34dcbee710e796d830b2be3c122e54830fbf/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java#L449
such that it now checks that all of the arguments given in `argv` are on the help page.

**2:**

It fixes the following help pages (trying out the toggle feature here, if they are causing issues let me know and I can post the before and after help pages in the comments),

<details>
<summary><b>dockstore plugin download --help</b></summary>

**Before:**
```
fhembroff@LL6496-Fhembr:~/Documents/work/incorrect-help-pages/dockstore-cli$ dockstore plugin download --help --script

 ____             _        _                 
|  _ \  ___   ___| | _____| |_ ___  _ __ ___ 
| | | |/ _ \ / __| |/ / __| __/ _ \| '__/ _ \
| |_| | (_) | (__|   <\__ \ || (_) | | |  __/
|____/ \___/ \___|_|\_\___/\__\___/|_|  \___|

---------------------------------------------
See https://www.dockstore.org for more information

Usage: dockstore plugin --help
       dockstore plugin [parameters] [command]

Description:
  Configure and debug plugins

Commands: 
  list
    List currently activated file provision plugins
  download
    Download default file provisioning plugins


---------------------------------------------


```
**After:**
```
fhembroff@LL6496-Fhembr:~/Documents/work/incorrect-help-pages/dockstore-cli$ java -jar dockstore-client/target/dockstore-client-1.14.0-SNAPSHOT-shaded.jar plugin download --help

 ____             _        _                 
|  _ \  ___   ___| | _____| |_ ___  _ __ ___ 
| | | |/ _ \ / __| |/ / __| __/ _ \| '__/ _ \
| |_| | (_) | (__|   <\__ \ || (_) | | |  __/
|____/ \___/ \___|_|\_\___/\__\___/|_|  \___|

---------------------------------------------
See https://www.dockstore.org for more information

Usage: dockstore plugin download --help
       dockstore plugin download [parameters]

Description:
  Download default file provisioning plugins



---------------------------------------------


```

</details>
<details>
<summary><b>dockstore plugin list --help</b></summary>

**Before:**
```
fhembroff@LL6496-Fhembr:~/Documents/work/incorrect-help-pages/dockstore-cli$ dockstore plugin list --help --script

 ____             _        _                 
|  _ \  ___   ___| | _____| |_ ___  _ __ ___ 
| | | |/ _ \ / __| |/ / __| __/ _ \| '__/ _ \
| |_| | (_) | (__|   <\__ \ || (_) | | |  __/
|____/ \___/ \___|_|\_\___/\__\___/|_|  \___|

---------------------------------------------
See https://www.dockstore.org for more information

Usage: dockstore plugin --help
       dockstore plugin [parameters] [command]

Description:
  Configure and debug plugins

Commands: 
  list
    List currently activated file provision plugins
  download
    Download default file provisioning plugins


---------------------------------------------


```
**After:**
```
fhembroff@LL6496-Fhembr:~/Documents/work/incorrect-help-pages/dockstore-cli$ java -jar dockstore-client/target/dockstore-client-1.14.0-SNAPSHOT-shaded.jar plugin list --help

 ____             _        _                 
|  _ \  ___   ___| | _____| |_ ___  _ __ ___ 
| | | |/ _ \ / __| |/ / __| __/ _ \| '__/ _ \
| |_| | (_) | (__|   <\__ \ || (_) | | |  __/
|____/ \___/ \___|_|\_\___/\__\___/|_|  \___|

---------------------------------------------
See https://www.dockstore.org for more information

Usage: dockstore plugin list --help
       dockstore plugin list [parameters]

Description:
  List currently activated file provision plugins



---------------------------------------------


```

</details>

The below were causing problems, as they were both saying that their usage was `dockstore verify`, the issue being, that there is no command called `dockstore verify`.

<details>
<summary><b>dockstore tool verify --help</b></summary>

**Before:**
```
fhembroff@LL6496-Fhembr:~/Documents/work/incorrect-help-pages/dockstore-cli$ dockstore tool verify --help --script

 ____             _        _                 
|  _ \  ___   ___| | _____| |_ ___  _ __ ___ 
| | | |/ _ \ / __| |/ / __| __/ _ \| '__/ _ \
| |_| | (_) | (__|   <\__ \ || (_) | | |  __/
|____/ \___/ \___|_|\_\___/\__\___/|_|  \___|

---------------------------------------------
See https://www.dockstore.org for more information

Usage: dockstore verify --help
       dockstore verify [parameters]

Description:
  Print cwltool runner dependencies

Required parameters:
  --trs-id <trs-id>                      TRS ID
  --version-id <version-id>              Version ID
  --file-path <file-path>                Path of the test JSON relative to the primary descriptor file
  --platform <platform>                  Platform to report on
  --metadata <metadata>                  Additional information on the verification (notes, explanation)
  --platform-version <platform-version>  Version of the platform to report on
  --descriptor-type <descriptor-type>    Descriptor Type (CWL, WDL, NFL)

Optional parameters:
  --unverify <unverify>                  Use flag to unverify
                                         Default: false

---------------------------------------------

```
**After:**
```
fhembroff@LL6496-Fhembr:~/Documents/work/incorrect-help-pages/dockstore-cli$ java -jar dockstore-client/target/dockstore-client-1.14.0-SNAPSHOT-shaded.jar tool verify --help

 ____             _        _                 
|  _ \  ___   ___| | _____| |_ ___  _ __ ___ 
| | | |/ _ \ / __| |/ / __| __/ _ \| '__/ _ \
| |_| | (_) | (__|   <\__ \ || (_) | | |  __/
|____/ \___/ \___|_|\_\___/\__\___/|_|  \___|

---------------------------------------------
See https://www.dockstore.org for more information

Usage: dockstore tool verify --help
       dockstore tool verify [parameters]

Description:
  Print cwltool runner dependencies

Required parameters:
  --trs-id <trs-id>                      TRS ID
  --version-id <version-id>              Version ID
  --file-path <file-path>                Path of the test JSON relative to the primary descriptor file
  --platform <platform>                  Platform to report on
  --metadata <metadata>                  Additional information on the verification (notes, explanation)
  --platform-version <platform-version>  Version of the platform to report on
  --descriptor-type <descriptor-type>    Descriptor Type (CWL, WDL, NFL)

Optional parameters:
  --unverify <unverify>                  Use flag to unverify
                                         Default: false

---------------------------------------------


```

</details>
<details>
<summary><b>dockstore workflow verify --help</b></summary>

**Before:**
```
fhembroff@LL6496-Fhembr:~/Documents/work/incorrect-help-pages/dockstore-cli$ dockstore workflow verify --help --script

 ____             _        _                 
|  _ \  ___   ___| | _____| |_ ___  _ __ ___ 
| | | |/ _ \ / __| |/ / __| __/ _ \| '__/ _ \
| |_| | (_) | (__|   <\__ \ || (_) | | |  __/
|____/ \___/ \___|_|\_\___/\__\___/|_|  \___|

---------------------------------------------
See https://www.dockstore.org for more information

Usage: dockstore verify --help
       dockstore verify [parameters]

Description:
  Print cwltool runner dependencies

Required parameters:
  --trs-id <trs-id>                      TRS ID
  --version-id <version-id>              Version ID
  --file-path <file-path>                Path of the test JSON relative to the primary descriptor file
  --platform <platform>                  Platform to report on
  --metadata <metadata>                  Additional information on the verification (notes, explanation)
  --platform-version <platform-version>  Version of the platform to report on
  --descriptor-type <descriptor-type>    Descriptor Type (CWL, WDL, NFL)

Optional parameters:
  --unverify <unverify>                  Use flag to unverify
                                         Default: false

---------------------------------------------


```
**After:**
```
fhembroff@LL6496-Fhembr:~/Documents/work/incorrect-help-pages/dockstore-cli$ java -jar dockstore-client/target/dockstore-client-1.14.0-SNAPSHOT-shaded.jar workflow verify --help

 ____             _        _                 
|  _ \  ___   ___| | _____| |_ ___  _ __ ___ 
| | | |/ _ \ / __| |/ / __| __/ _ \| '__/ _ \
| |_| | (_) | (__|   <\__ \ || (_) | | |  __/
|____/ \___/ \___|_|\_\___/\__\___/|_|  \___|

---------------------------------------------
See https://www.dockstore.org for more information

Usage: dockstore workflow verify --help
       dockstore workflow verify [parameters]

Description:
  Print cwltool runner dependencies

Required parameters:
  --trs-id <trs-id>                      TRS ID
  --version-id <version-id>              Version ID
  --file-path <file-path>                Path of the test JSON relative to the primary descriptor file
  --platform <platform>                  Platform to report on
  --metadata <metadata>                  Additional information on the verification (notes, explanation)
  --platform-version <platform-version>  Version of the platform to report on
  --descriptor-type <descriptor-type>    Descriptor Type (CWL, WDL, NFL)

Optional parameters:
  --unverify <unverify>                  Use flag to unverify
                                         Default: false

---------------------------------------------


```

</details>

Finally, I corrected the help page for `dockstore checker update_version`. As it was showing the help page for `dockstore checker version_tag` instead. After reading through the [code](https://github.com/dockstore/dockstore-cli/blob/411f34dcbee710e796d830b2be3c122e54830fbf/dockstore-client/src/main/java/io/dockstore/client/cli/CheckerClient.java#L367-L390) for `dockstore checker update_version` it appears that it gets the checker workflow for an entry and then passes it to the `version_tag` code (unfortunately there are no tests for this code, at least that I could find). So, I essentially made the help page for `dockstore checker update_version` the same as `dockstore workflow version_tag`.

<details>
<summary><b>dockstore checker update_version --help</b></summary>

**Before:**
```
fhembroff@LL6496-Fhembr:~/Documents/work/incorrect-help-pages/dockstore-cli$ dockstore checker update_version --help --script

 ____             _        _                 
|  _ \  ___   ___| | _____| |_ ___  _ __ ___ 
| | | |/ _ \ / __| |/ / __| __/ _ \| '__/ _ \
| |_| | (_) | (__|   <\__ \ || (_) | | |  __/
|____/ \___/ \___|_|\_\___/\__\___/|_|  \___|

---------------------------------------------
See https://www.dockstore.org for more information

Usage: dockstore checker version_tag --help
       dockstore checker version_tag [parameters]

Description:
  Update certain fields for a given checker version.

Required Parameters:
  --entry <entry>                                      Complete checker path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)
  --name <name>                                        Name of the checker version.

Optional Parameters
  --workflow-path <workflow-path>                      Path to checker descriptor
  --hidden <true/false>                                Hide the tag from public viewing, default false

---------------------------------------------


```
**After:**
```
fhembroff@LL6496-Fhembr:~/Documents/work/incorrect-help-pages/dockstore-cli$ java -jar dockstore-client/target/dockstore-client-1.14.0-SNAPSHOT-shaded.jar checker update_version --help --script

 ____             _        _                 
|  _ \  ___   ___| | _____| |_ ___  _ __ ___ 
| | | |/ _ \ / __| |/ / __| __/ _ \| '__/ _ \
| |_| | (_) | (__|   <\__ \ || (_) | | |  __/
|____/ \___/ \___|_|\_\___/\__\___/|_|  \___|

---------------------------------------------
See https://www.dockstore.org for more information

Usage: dockstore checker update_version --help
       dockstore checker update_version [parameters]

Updates a specific version of an existing checker workflow.

Required Parameters:
  --entry <entry>                                      Complete checker path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)
  --name <name>                                        Name of the checker version.

Optional Parameters
  --workflow-path <workflow-path>                      Path to checker descriptor
  --hidden <true/false>                                Hide the tag from public viewing, default false

---------------------------------------------


```

</details>

**Review Instructions**
Ensure that my modified test runs, and that the help page for `dockstore checker update_version --help` is valid.

**Issue**
https://github.com/dockstore/dockstore/issues/5342
[DOCK-2318](https://ucsc-cgl.atlassian.net/browse/DOCK-2318)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.


[DOCK-2318]: https://ucsc-cgl.atlassian.net/browse/DOCK-2318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ