### PR TITLE
Moved CWL and WDL to constants

### DIFF
--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
@@ -22,7 +22,6 @@ import java.util.List;
 import io.dockstore.client.cli.nested.ToolClient;
 import io.dockstore.common.CLICommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
-import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.Registry;
 import io.dockstore.common.SlowTest;
 import io.dockstore.common.ToolTest;
@@ -57,6 +56,8 @@ import static io.dockstore.client.cli.nested.ToolClient.UPDATE_TOOL;
 import static io.dockstore.client.cli.nested.ToolClient.VERSION_TAG;
 import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
 import static io.dockstore.client.cli.nested.WesCommandParser.JSON;
+import static io.dockstore.common.DescriptorLanguage.CWL;
+import static io.dockstore.common.DescriptorLanguage.WDL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -371,7 +372,7 @@ class BasicIT extends BaseIT {
 
         // Update tag with test parameters
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file.txt"), TOOL, TEST_PARAMETER, ENTRY,
-            "quay.io/dockstoretestuser/test_input_json", VERSION, "master", "--descriptor-type", "cwl", "--add", "test.cwl.json",
+            "quay.io/dockstoretestuser/test_input_json", VERSION, "master", "--descriptor-type", CWL.toString(), "--add", "test.cwl.json",
             // Trying to remove a non-existent parameter file now fails
             "--add", "test2.cwl.json", "--add", "fake.cwl.json", /*"--remove", "notreal.cwl.json",*/ SCRIPT_FLAG });
         final long count2 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type like '%_TEST_JSON'", long.class);
@@ -379,20 +380,20 @@ class BasicIT extends BaseIT {
 
         // Update tag with test parameters
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file.txt"), TOOL, TEST_PARAMETER, ENTRY,
-            "quay.io/dockstoretestuser/test_input_json", VERSION, "master", "--descriptor-type", "cwl", "--add", "test.cwl.json",
+            "quay.io/dockstoretestuser/test_input_json", VERSION, "master", "--descriptor-type", CWL.toString(), "--add", "test.cwl.json",
             "--remove", "test2.cwl.json", SCRIPT_FLAG });
         final long count3 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type like '%_TEST_JSON'", long.class);
         assertEquals(1, count3, "there should be one sourcefile that is a test parameter file, there are " + count3);
 
         // Update tag wdltest with test parameters
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file.txt"), TOOL, TEST_PARAMETER, ENTRY,
-            "quay.io/dockstoretestuser/test_input_json", VERSION, "wdltest", "--descriptor-type", "wdl", "--add", "test.wdl.json",
+            "quay.io/dockstoretestuser/test_input_json", VERSION, "wdltest", "--descriptor-type", WDL.toString(), "--add", "test.wdl.json",
             SCRIPT_FLAG });
         final long count4 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type='WDL_TEST_JSON'", long.class);
         assertEquals(1, count4, "there should be one sourcefile that is a wdl test parameter file, there are " + count4);
 
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file.txt"), TOOL, TEST_PARAMETER, ENTRY,
-            "quay.io/dockstoretestuser/test_input_json", VERSION, "wdltest", "--descriptor-type", "cwl", "--add", "test.cwl.json",
+            "quay.io/dockstoretestuser/test_input_json", VERSION, "wdltest", "--descriptor-type", CWL.toString(), "--add", "test.cwl.json",
             SCRIPT_FLAG });
         final long count5 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type='CWL_TEST_JSON'", long.class);
         assertEquals(2, count5, "there should be two sourcefiles that are test parameter files, there are " + count5);
@@ -797,7 +798,7 @@ class BasicIT extends BaseIT {
         final ApiClient webClient = getWebClient(BaseIT.USER_1_USERNAME, testingPostgres);
         HostedApi hostedApi = new HostedApi(webClient);
         hostedApi.createHostedTool("testHosted", Registry.QUAY_IO.getDockerPath().toLowerCase(),
-                DescriptorLanguage.CWL.getShortName(), "hostedToolNamespace", null);
+                CWL.getShortName(), "hostedToolNamespace", null);
 
         // verify there is an unpublished hosted tool
         final long initialUnpublishedHostedCount = testingPostgres.runSelectStatement(

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
@@ -30,7 +30,6 @@ import io.swagger.client.ApiClient;
 import io.swagger.client.api.ContainersApi;
 import io.swagger.client.api.HostedApi;
 import io.swagger.client.model.DockstoreTool;
-import io.swagger.model.DescriptorType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
@@ -429,21 +428,21 @@ class BasicIT extends BaseIT {
         assertEquals(0, count, "there should be no sourcefiles that are test parameter files, there are " + count);
 
         containersApi
-            .addTestParameterFiles(containerByToolPath.getId(), Collections.singletonList("/test.json"), DescriptorType.CWL.toString(), "",
+            .addTestParameterFiles(containerByToolPath.getId(), Collections.singletonList("/test.json"), CWL.toString(), "",
                 "master");
 
         boolean shouldFail = false;
         try {
             final ContainersApi containersApi1 = new ContainersApi(otherWebClient);
             containersApi1.addTestParameterFiles(containerByToolPath.getId(), Collections.singletonList("/test2.cwl.json"),
-                DescriptorType.CWL.toString(), "", "master");
+                CWL.toString(), "", "master");
         } catch (Exception e) {
             shouldFail = true;
         }
         assertTrue(shouldFail);
 
         containersApi
-            .addTestParameterFiles(containerByToolPath.getId(), Collections.singletonList("/test2.cwl.json"), DescriptorType.CWL.toString(),
+            .addTestParameterFiles(containerByToolPath.getId(), Collections.singletonList("/test2.cwl.json"), CWL.toString(),
                 "", "master");
 
         final long count3 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type like '%_TEST_JSON'", long.class);
@@ -454,16 +453,16 @@ class BasicIT extends BaseIT {
         try {
             final ContainersApi containersApi1 = new ContainersApi(otherWebClient);
             containersApi1.deleteTestParameterFiles(containerByToolPath.getId(), Collections.singletonList("/test2.cwl.json"),
-                DescriptorType.CWL.toString(), "master");
+                CWL.toString(), "master");
         } catch (Exception e) {
             shouldFail = true;
         }
         assertTrue(shouldFail);
         containersApi
-            .deleteTestParameterFiles(containerByToolPath.getId(), Collections.singletonList("/test.json"), DescriptorType.CWL.toString(),
+            .deleteTestParameterFiles(containerByToolPath.getId(), Collections.singletonList("/test.json"), CWL.toString(),
                 "master");
         containersApi.deleteTestParameterFiles(containerByToolPath.getId(), Collections.singletonList("/test2.cwl.json"),
-            DescriptorType.CWL.toString(), "master");
+            CWL.toString(), "master");
 
         final long count4 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type like '%_TEST_JSON'", long.class);
         assertEquals(0, count4, "there should be one sourcefile that is a test parameter file, there are " + count4);

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
@@ -449,18 +449,48 @@ class ClientIT extends BaseIT {
     }
 
     /**
-     * This method passes all the values in argv and --help if includeHelpFlag is true to Client.main and ensures
-     * that the output contains,
-     * 1) "Usage: dockstore", this ensures that some help page is being displayed
-     * 2) "dockstore" followed by the strings in argv, for example, if argv = {"test", "blue", "green"}, it would ensure
-     * that the output contained the string "dockstore test blue green"
-     *
-     * @param argv the arguments to pass to Client.main, do not pass "--help"
-     * @param includeHelpFlag If true, "--help" will be passed to Client.main after the arguments in argv
+     * This test ensures that a help page is still displayed for workflow WDL, if "wdl" is used instead of "WDL"
+     * @throws IOException
+     */
+    @Test
+    void checkWDLHelpMessageWithDifferentCapitalization() throws IOException {
+        checkCommandForHelp(new String[] { WORKFLOW, WDL.toString().toLowerCase() }, new String[] { WORKFLOW, WDL.toString() }, false);
+    }
+
+    /**
+     * This test ensures that a help page is still displayed for workflow CWL, if "cwl" is used instead of "CWL"
+     * @throws IOException
+     */
+    @Test
+    void checkCWLHelpMessageWithDifferentCapitalization() throws IOException {
+        checkCommandForHelp(new String[] { WORKFLOW, CWL.toString().toLowerCase() }, new String[] { WORKFLOW, CWL.toString() }, false);
+    }
+
+    /**
+     * This method calls checkCommandForHelp, with both commandsToBePassed and commandsThatShouldBeInHelpMessage set to argv
+     * @param argv
+     * @param includeHelpFlag
      * @throws IOException
      */
     private void checkCommandForHelp(String[] argv, boolean includeHelpFlag) throws IOException {
-        final ArrayList<String> strings = Lists.newArrayList(argv);
+        checkCommandForHelp(argv, argv, includeHelpFlag);
+    }
+
+    /**
+     * This method passes all the values in argv and --help if includeHelpFlag is true to Client.main and ensures
+     * that the output contains,
+     * 1) "Usage: dockstore", this ensures that some help page is being displayed
+     * 2) "dockstore" followed by the strings in commandsThatShouldBeInHelpMessage,
+     * for example, if commandsThatShouldBeInHelpMessage = {"test", "blue", "green"}, it would ensure
+     * that the output contained the string "dockstore test blue green"
+     *
+     * @param commandsToBePassed the arguments to pass to Client.main, do not pass "--help"
+     * @param commandsThatShouldBeInHelpMessage
+     * @param includeHelpFlag If true, "--help" will be passed to Client.main after the arguments in argv
+     * @throws IOException
+     */
+    private void checkCommandForHelp(String[] commandsToBePassed, String[] commandsThatShouldBeInHelpMessage, boolean includeHelpFlag) throws IOException {
+        final ArrayList<String> strings = Lists.newArrayList(commandsToBePassed);
         if (includeHelpFlag) {
             strings.add(HELP);
         }
@@ -470,10 +500,12 @@ class ClientIT extends BaseIT {
         Client.main(strings.toArray(new String[0]));
         assertTrue(systemOutRule.getText().contains("Usage: dockstore"), "'Usage: dockstore' isn't being displayed, this probably means"
                 + "that no help page is being shown");
-        assertTrue(systemOutRule.getText().contains("dockstore " + join(" ", argv)), "`Usage: dockstore` is being displayed"
+        assertTrue(systemOutRule.getText().contains("dockstore " + join(" ", commandsThatShouldBeInHelpMessage)), "`Usage: dockstore` is being displayed"
                 + "but it does not contain the strings found in argv, this probably means the wrong help page is being displayed");
         systemOutRule.clear();
     }
+
+
 
 
     @Test

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
@@ -86,6 +86,8 @@ import static io.dockstore.client.cli.nested.WesCommandParser.PAGE_TOKEN;
 import static io.dockstore.client.cli.nested.WesCommandParser.WES_URL;
 import static io.dockstore.client.cli.nested.WorkflowClient.UPDATE_WORKFLOW;
 import static io.dockstore.common.CLICommonTestUtilities.checkToolList;
+import static io.dockstore.common.DescriptorLanguage.CWL;
+import static io.dockstore.common.DescriptorLanguage.WDL;
 import static io.github.collaboratory.cwl.CWLClient.WES;
 import static java.lang.String.join;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -349,8 +351,8 @@ class ClientIT extends BaseIT {
 
         checkCommandForHelp(new String[] { TOOL, SEARCH }, false);
         checkCommandForHelp(new String[] { TOOL, INFO }, false);
-        checkCommandForHelp(new String[] { TOOL, "CWL" }, false);
-        checkCommandForHelp(new String[] { TOOL, "WDL" }, false);
+        checkCommandForHelp(new String[] { TOOL, CWL.toString() }, false);
+        checkCommandForHelp(new String[] { TOOL, WDL.toString() }, false);
         checkCommandForHelp(new String[] { TOOL, LABEL }, false);
         checkCommandForHelp(new String[] { TOOL, TEST_PARAMETER }, false);
         checkCommandForHelp(new String[] { TOOL, CONVERT }, false);
@@ -370,8 +372,8 @@ class ClientIT extends BaseIT {
         checkCommandForHelp(new String[] { TOOL, SEARCH }, true);
         checkCommandForHelp(new String[] { TOOL, PUBLISH }, true);
         checkCommandForHelp(new String[] { TOOL, INFO }, true);
-        checkCommandForHelp(new String[] { TOOL, "CWL" }, true);
-        checkCommandForHelp(new String[] { TOOL, "WDL" }, true);
+        checkCommandForHelp(new String[] { TOOL, CWL.toString() }, true);
+        checkCommandForHelp(new String[] { TOOL, WDL.toString() }, true);
         checkCommandForHelp(new String[] { TOOL, REFRESH }, true);
         checkCommandForHelp(new String[] { TOOL, LABEL }, true);
         checkCommandForHelp(new String[] { TOOL, CONVERT }, true);
@@ -398,8 +400,8 @@ class ClientIT extends BaseIT {
 
         checkCommandForHelp(new String[] { WORKFLOW, SEARCH }, false);
         checkCommandForHelp(new String[] { WORKFLOW, INFO }, false);
-        checkCommandForHelp(new String[] { WORKFLOW, "CWL" }, false);
-        checkCommandForHelp(new String[] { WORKFLOW, "WDL" }, false);
+        checkCommandForHelp(new String[] { WORKFLOW, CWL.toString() }, false);
+        checkCommandForHelp(new String[] { WORKFLOW, WDL.toString() }, false);
         checkCommandForHelp(new String[] { WORKFLOW, LABEL }, false);
         checkCommandForHelp(new String[] { WORKFLOW, TEST_PARAMETER }, false);
         checkCommandForHelp(new String[] { WORKFLOW, CONVERT }, false);
@@ -413,8 +415,8 @@ class ClientIT extends BaseIT {
         checkCommandForHelp(new String[] { WORKFLOW, SEARCH }, true);
         checkCommandForHelp(new String[] { WORKFLOW, PUBLISH }, true);
         checkCommandForHelp(new String[] { WORKFLOW, INFO }, true);
-        checkCommandForHelp(new String[] { WORKFLOW, "CWL" }, true);
-        checkCommandForHelp(new String[] { WORKFLOW, "WDL" }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, CWL.toString() }, true);
+        checkCommandForHelp(new String[] { WORKFLOW, WDL.toString() }, true);
         checkCommandForHelp(new String[] { WORKFLOW, REFRESH }, true);
         checkCommandForHelp(new String[] { WORKFLOW, LABEL }, true);
         checkCommandForHelp(new String[] { WORKFLOW, CONVERT }, true);

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -63,6 +63,8 @@ import static io.dockstore.client.cli.nested.AbstractEntryClient.WDL_2_JSON;
 import static io.dockstore.client.cli.nested.ToolClient.VERSION_TAG;
 import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
 import static io.dockstore.client.cli.nested.WesCommandParser.JSON;
+import static io.dockstore.common.DescriptorLanguage.CWL;
+import static io.dockstore.common.DescriptorLanguage.WDL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -135,7 +137,7 @@ class GeneralIT extends BaseIT {
     void testLocalLaunchWDLNoFile() throws Exception {
         int exitCode = catchSystemExit(() -> Client.main(
                 new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), TOOL, LAUNCH, "--local-entry",
-                        "imnotreal.wdl", JSON, "imnotreal-job.json", "--descriptor", "wdl", SCRIPT_FLAG }));
+                        "imnotreal.wdl", JSON, "imnotreal-job.json", "--descriptor", WDL.toString(), SCRIPT_FLAG }));
         assertEquals(Client.ENTRY_NOT_FOUND, exitCode);
     }
 
@@ -157,7 +159,7 @@ class GeneralIT extends BaseIT {
     void testRemoteLaunchWDLNoFile() throws Exception {
         int exitCode = catchSystemExit(() ->  Client.main(
                 new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), TOOL, LAUNCH, ENTRY, "imnotreal.wdl",
-                        JSON, "imnotreal-job.json", "--descriptor", "wdl", SCRIPT_FLAG }));
+                        JSON, "imnotreal-job.json", "--descriptor", WDL.toString(), SCRIPT_FLAG }));
         assertEquals(Client.ENTRY_NOT_FOUND, exitCode);
     }
 
@@ -339,7 +341,7 @@ class GeneralIT extends BaseIT {
         // need to publish before converting
         Client.main(
             new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), TOOL, CONVERT, ENTRY_2_JSON, ENTRY,
-                "quay.io/dockstoretestuser2/quayandgithubwdl", "--descriptor", "wdl", SCRIPT_FLAG });
+                "quay.io/dockstoretestuser2/quayandgithubwdl", "--descriptor", WDL.toString(), SCRIPT_FLAG });
         assertTrue(systemOutRule.getText().contains("\"test.hello.name\": \"String\""));
     }
 
@@ -416,11 +418,11 @@ class GeneralIT extends BaseIT {
     void testGetWdlAndCwl() {
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), TOOL, PUBLISH, ENTRY,
             "quay.io/dockstoretestuser2/quayandgithubwdl" });
-        Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), TOOL, "wdl", ENTRY,
+        Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), TOOL, WDL.toString(), ENTRY,
             "quay.io/dockstoretestuser2/quayandgithubwdl", SCRIPT_FLAG });
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), TOOL, PUBLISH, ENTRY,
             "quay.io/dockstoretestuser2/quayandgithub" });
-        Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), TOOL, "cwl", ENTRY,
+        Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), TOOL, CWL.toString(), ENTRY,
             "quay.io/dockstoretestuser2/quayandgithub", SCRIPT_FLAG });
     }
 
@@ -430,7 +432,7 @@ class GeneralIT extends BaseIT {
     @Test
     void testGetWdlFailure() throws Exception {
         int exitCode = catchSystemExit(() -> Client.main(
-                new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), TOOL, "wdl", ENTRY,
+                new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), TOOL, WDL.toString(), ENTRY,
                         "quay.io/dockstoretestuser2/quayandgithub", SCRIPT_FLAG }));
         assertEquals(Client.API_ERROR, exitCode);
     }

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -56,6 +56,7 @@ import static io.dockstore.client.cli.nested.AbstractEntryClient.TEST_PARAMETER;
 import static io.dockstore.client.cli.nested.ToolClient.VERSION_TAG;
 import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
 import static io.dockstore.client.cli.nested.WorkflowClient.UPDATE_WORKFLOW;
+import static io.dockstore.common.DescriptorLanguage.WDL;
 import static io.dockstore.webservice.resources.WorkflowResource.FROZEN_VERSION_REQUIRED;
 import static io.dockstore.webservice.resources.WorkflowResource.NO_ZENDO_USER_TOKEN;
 import static io.swagger.client.model.ToolDescriptor.TypeEnum.CWL;
@@ -228,7 +229,7 @@ class GeneralWorkflowIT extends BaseIT {
         refreshByOrganizationReplacement(USER_2_USERNAME, Set.of(SourceControl.GITHUB + "/DockstoreTestUser2/hello-dockstore-workflow"));
         Client.main(
             new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, UPDATE_WORKFLOW, ENTRY,
-                SourceControl.GITHUB + "/DockstoreTestUser2/hello-dockstore-workflow", "--descriptor-type", "wdl", SCRIPT_FLAG });
+                SourceControl.GITHUB + "/DockstoreTestUser2/hello-dockstore-workflow", "--descriptor-type", WDL.toString(), SCRIPT_FLAG });
 
         final long count = testingPostgres.runSelectStatement("select count(*) from workflow where descriptortype = 'wdl'", long.class);
         assertEquals(1, count, "there should be 1 wdl workflow, there are " + count);
@@ -237,7 +238,7 @@ class GeneralWorkflowIT extends BaseIT {
             SourceControl.GITHUB + "/DockstoreTestUser2/hello-dockstore-workflow", SCRIPT_FLAG });
         int exitCode = catchSystemExit(() -> Client.main(
                 new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, UPDATE_WORKFLOW, ENTRY,
-                        SourceControl.GITHUB + "/DockstoreTestUser2/hello-dockstore-workflow", "--descriptor-type", "cwl", SCRIPT_FLAG }));
+                        SourceControl.GITHUB + "/DockstoreTestUser2/hello-dockstore-workflow", "--descriptor-type", CWL.toString(), SCRIPT_FLAG }));
         assertEquals(Client.CLIENT_ERROR, exitCode);
     }
 
@@ -325,7 +326,7 @@ class GeneralWorkflowIT extends BaseIT {
         Client.main(
             new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, UPDATE_WORKFLOW, ENTRY,
                 SourceControl.GITHUB + "/DockstoreTestUser2/hello-dockstore-workflow", "--workflow-path", "Dockstore.wdl",
-                "--descriptor-type", "wdl", SCRIPT_FLAG });
+                "--descriptor-type", WDL.toString(), SCRIPT_FLAG });
 
         // Can now publish workflow
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, PUBLISH, ENTRY,
@@ -432,7 +433,7 @@ class GeneralWorkflowIT extends BaseIT {
             SourceControl.GITLAB + "/dockstore.test.user2/dockstore-workflow-example", SCRIPT_FLAG });
 
         // Should be able to grab descriptor
-        Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, "cwl", ENTRY,
+        Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, CWL.toString(), ENTRY,
             SourceControl.GITLAB + "/dockstore.test.user2/dockstore-workflow-example:master", SCRIPT_FLAG });
 
         // unpublish
@@ -472,7 +473,7 @@ class GeneralWorkflowIT extends BaseIT {
         // Convert to WDL workflow
         Client.main(
             new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, UPDATE_WORKFLOW, ENTRY,
-                SourceControl.GITLAB + "/dockstore.test.user2/dockstore-workflow-example", "--descriptor-type", "wdl",
+                SourceControl.GITLAB + "/dockstore.test.user2/dockstore-workflow-example", "--descriptor-type", WDL.toString(),
                 SCRIPT_FLAG });
 
         // Should now be a WDL workflow
@@ -495,7 +496,7 @@ class GeneralWorkflowIT extends BaseIT {
         // Update workflow to be WDL with correct path
         Client.main(
             new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, UPDATE_WORKFLOW, ENTRY,
-                SourceControl.GITHUB + "/DockstoreTestUser2/test_workflow_wdl", "--descriptor-type", "wdl", "--workflow-path",
+                SourceControl.GITHUB + "/DockstoreTestUser2/test_workflow_wdl", "--descriptor-type", WDL.toString(), "--workflow-path",
                 "/hello.wdl", SCRIPT_FLAG });
 
         // Check for WDL files
@@ -553,7 +554,7 @@ class GeneralWorkflowIT extends BaseIT {
         // Change to WDL
         Client.main(
             new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, UPDATE_WORKFLOW, ENTRY,
-                SourceControl.GITHUB + "/DockstoreTestUser2/parameter_test_workflow", "--descriptor-type", "wdl",
+                SourceControl.GITHUB + "/DockstoreTestUser2/parameter_test_workflow", "--descriptor-type", WDL.toString(),
                 "--workflow-path", "Dockstore.wdl", SCRIPT_FLAG });
 
         // Should be no sourcefiles
@@ -598,7 +599,7 @@ class GeneralWorkflowIT extends BaseIT {
 
         //register workflow
         Workflow githubWorkflow = workflowApi
-            .manualRegister("github", "DockstoreTestUser2/test_lastmodified", "/hello.wdl", "test-update-workflow", "wdl", "/test.json");
+            .manualRegister("github", "DockstoreTestUser2/test_lastmodified", "/hello.wdl", "test-update-workflow", WDL.toString(), "/test.json");
 
         Workflow workflowBeforeFreezing = workflowApi.refresh(githubWorkflow.getId(), true);
         WorkflowVersion master = workflowBeforeFreezing.getWorkflowVersions().stream().filter(v -> v.getName().equals("master")).findFirst()

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GitHubAppToolIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GitHubAppToolIT.java
@@ -38,6 +38,7 @@ import static io.dockstore.client.cli.nested.ToolClient.VERSION_TAG;
 import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
 import static io.dockstore.client.cli.nested.WesCommandParser.JSON;
 import static io.dockstore.client.cli.nested.WorkflowClient.UPDATE_WORKFLOW;
+import static io.dockstore.common.DescriptorLanguage.CWL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.org.webcompere.systemstubs.SystemStubs.catchSystemExit;
@@ -108,7 +109,7 @@ class GitHubAppToolIT extends BaseIT {
 
     @Test
     void cwl() {
-        Client.main(new String[]{WORKFLOW, DescriptorType.CWL.toString(), ENTRY, ENTRY_PATH_WITH_VERSION, CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt")});
+        Client.main(new String[]{WORKFLOW, CWL.toString(), ENTRY, ENTRY_PATH_WITH_VERSION, CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt")});
         assertTrue(systemOutRule.getText().contains("label: Simple md5sum tool"));
     }
 

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GitHubAppToolIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/GitHubAppToolIT.java
@@ -5,7 +5,6 @@ import io.dockstore.common.FlushingSystemErr;
 import io.dockstore.common.FlushingSystemOut;
 import io.dockstore.openapi.client.model.WorkflowSubClass;
 import io.dropwizard.testing.ResourceHelpers;
-import io.openapi.model.DescriptorType;
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
 import io.swagger.client.api.WorkflowsApi;
@@ -39,6 +38,7 @@ import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
 import static io.dockstore.client.cli.nested.WesCommandParser.JSON;
 import static io.dockstore.client.cli.nested.WorkflowClient.UPDATE_WORKFLOW;
 import static io.dockstore.common.DescriptorLanguage.CWL;
+import static io.dockstore.common.DescriptorLanguage.WDL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.org.webcompere.systemstubs.SystemStubs.catchSystemExit;
@@ -115,7 +115,7 @@ class GitHubAppToolIT extends BaseIT {
 
     @Test
     void wdl() throws Exception {
-        int exitCode = catchSystemExit(() -> Client.main(new String[]{WORKFLOW, DescriptorType.WDL.toString(), ENTRY, ENTRY_PATH_WITH_VERSION, CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt")}));
+        int exitCode = catchSystemExit(() -> Client.main(new String[]{WORKFLOW, WDL.toString(), ENTRY, ENTRY_PATH_WITH_VERSION, CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt")}));
         assertEquals(Client.API_ERROR, exitCode);
         assertTrue(systemErrRule.getOutput().getText().contains("Invalid version"), "stderr missing invalid version message, looked like " + systemErrRule.getOutput().getText());
     }

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/LaunchWorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/LaunchWorkflowIT.java
@@ -24,6 +24,7 @@ import static io.dockstore.client.cli.nested.AbstractEntryClient.MANUAL_PUBLISH;
 import static io.dockstore.client.cli.nested.AbstractEntryClient.PUBLISH;
 import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
 import static io.dockstore.client.cli.nested.WesCommandParser.JSON;
+import static io.dockstore.common.DescriptorLanguage.CWL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.org.webcompere.systemstubs.SystemStubs.catchSystemExit;
@@ -158,7 +159,7 @@ class LaunchWorkflowIT extends BaseIT {
         Client.main(
             new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, MANUAL_PUBLISH, "--repository",
                 "md5sum-checker", "--organization", "DockstoreTestUser2", "--git-version-control", "github",
-                "--workflow-path", "/checker-workflow-wrapping-tool.cwl", "--descriptor-type", "cwl", "--workflow-name", "checksumTester", SCRIPT_FLAG });
+                "--workflow-path", "/checker-workflow-wrapping-tool.cwl", "--descriptor-type", CWL.toString(), "--workflow-name", "checksumTester", SCRIPT_FLAG });
 
         // ensure checksum validation is acknowledged, and no null checksums were discovered
         systemOutRule.clear();

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ManualPublishWorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ManualPublishWorkflowIT.java
@@ -31,6 +31,8 @@ import static io.dockstore.client.cli.nested.AbstractEntryClient.VERIFY;
 import static io.dockstore.client.cli.nested.ToolClient.VERSION_TAG;
 import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
 import static io.dockstore.client.cli.nested.WorkflowClient.UPDATE_WORKFLOW;
+import static io.dockstore.common.DescriptorLanguage.CWL;
+import static io.dockstore.common.DescriptorLanguage.WDL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.org.webcompere.systemstubs.SystemStubs.catchSystemExit;
@@ -60,12 +62,12 @@ class ManualPublishWorkflowIT extends BaseIT {
         Client.main(
             new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, MANUAL_PUBLISH, "--repository",
                 "hello-dockstore-workflow", "--organization", "DockstoreTestUser2", "--git-version-control", "github", "--workflow-name",
-                "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", "wdl", SCRIPT_FLAG });
+                "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", WDL.toString(), SCRIPT_FLAG });
 
         int exitCode = catchSystemExit(() ->   Client.main(
                 new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, MANUAL_PUBLISH, "--repository",
                         "hello-dockstore-workflow", "--organization", "DockstoreTestUser2", "--git-version-control", "github", "--workflow-name",
-                        "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", "wdl", SCRIPT_FLAG }));
+                        "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", WDL.toString(), SCRIPT_FLAG }));
         assertEquals(Client.API_ERROR, exitCode);
     }
 
@@ -79,7 +81,7 @@ class ManualPublishWorkflowIT extends BaseIT {
         Client.main(
             new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, MANUAL_PUBLISH, "--repository",
                 "hello-dockstore-workflow", "--organization", "DockstoreTestUser2", "--git-version-control", "github", "--workflow-name",
-                "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", "wdl", SCRIPT_FLAG });
+                "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", WDL.toString(), SCRIPT_FLAG });
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, VERSION_TAG, ENTRY,
             SourceControl.GITHUB + "/DockstoreTestUser2/hello-dockstore-workflow/testname", "--name", "master",
             "--workflow-path", "/Dockstore2.wdl", SCRIPT_FLAG });
@@ -158,7 +160,7 @@ class ManualPublishWorkflowIT extends BaseIT {
         Client.main(
             new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, MANUAL_PUBLISH, "--repository",
                 "dockstore-workflow-example", "--organization", "dockstore.test.user2", "--git-version-control", "gitlab",
-                "--workflow-name", "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", "wdl", SCRIPT_FLAG });
+                "--workflow-name", "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", WDL.toString(), SCRIPT_FLAG });
 
         // Check for one valid version
         final long count = testingPostgres.runSelectStatement("select count(*) from workflowversion where valid='t'", long.class);
@@ -169,7 +171,7 @@ class ManualPublishWorkflowIT extends BaseIT {
         assertEquals(0, count2, "All GitLab workflow versions should have last modified populated when manual published");
 
         // grab wdl file
-        Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, "wdl", ENTRY,
+        Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, WDL.toString(), ENTRY,
             SourceControl.GITLAB + "/dockstore.test.user2/dockstore-workflow-example/testname:master", SCRIPT_FLAG });
     }
 
@@ -184,7 +186,7 @@ class ManualPublishWorkflowIT extends BaseIT {
         Client.main(
             new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, MANUAL_PUBLISH, "--repository",
                 "dockstore-workflow-md5sum-unified", "--organization", "dockstore.test.user2", "--git-version-control", "gitlab",
-                "--workflow-name", "testname", "--workflow-path", "/checker.wdl", "--descriptor-type", "wdl", SCRIPT_FLAG });
+                "--workflow-name", "testname", "--workflow-path", "/checker.wdl", "--descriptor-type", WDL.toString(), SCRIPT_FLAG });
 
         final long count = testingPostgres.runSelectStatement("select count(*) from workflowversion", long.class);
         assertTrue(count >= 5, "there should be at least 5 versions, there are " + count);
@@ -211,7 +213,7 @@ class ManualPublishWorkflowIT extends BaseIT {
         Client.main(
             new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, MANUAL_PUBLISH, "--repository",
                 "parameter_test_workflow", "--organization", "DockstoreTestUser2", "--git-version-control", "github", "--workflow-path",
-                "/Dockstore.cwl", "--descriptor-type", "cwl", SCRIPT_FLAG });
+                "/Dockstore.cwl", "--descriptor-type", CWL.toString(), SCRIPT_FLAG });
 
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, TEST_PARAMETER, "--add",
             "/test.wdl.json", ENTRY, SourceControl.GITHUB + "/DockstoreTestUser2/parameter_test_workflow", VERSION,
@@ -227,7 +229,7 @@ class ManualPublishWorkflowIT extends BaseIT {
         // Verify workflowversion
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, VERIFY, "--trs-id",
             "#workflow/github.com/DockstoreTestUser2/parameter_test_workflow", "--version-id", "wdltest", "--file-path", "test.wdl.json",
-            "--descriptor-type", "cwl", "--platform", "Cromwell", "--platform-version", "thing", "--metadata", "Docker testing group",
+            "--descriptor-type", CWL.toString(), "--platform", "Cromwell", "--platform-version", "thing", "--metadata", "Docker testing group",
             SCRIPT_FLAG });
 
         // Version should be verified
@@ -239,7 +241,7 @@ class ManualPublishWorkflowIT extends BaseIT {
         // Update workflowversion to have another verified source
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, VERIFY, "--trs-id",
             "#workflow/github.com/DockstoreTestUser2/parameter_test_workflow", "--version-id", "wdltest", "--file-path", "test.wdl.json",
-            "--descriptor-type", "cwl", "--platform", "Cromwell", "--platform-version", "thing", "--metadata", "Docker testing group2",
+            "--descriptor-type", CWL.toString(), "--platform", "Cromwell", "--platform-version", "thing", "--metadata", "Docker testing group2",
             SCRIPT_FLAG });
 
         // Version should have new verified source
@@ -251,7 +253,7 @@ class ManualPublishWorkflowIT extends BaseIT {
         // Verify another version
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, VERIFY, "--trs-id",
             "#workflow/github.com/DockstoreTestUser2/parameter_test_workflow", "--version-id", "master", "--file-path", "test.cwl.json",
-            "--descriptor-type", "cwl", "--platform", "Cromwell", "--platform-version", "thing", "--metadata", "Docker testing group",
+            "--descriptor-type", CWL.toString(), "--platform", "Cromwell", "--platform-version", "thing", "--metadata", "Docker testing group",
             SCRIPT_FLAG });
 
         // Version should be verified
@@ -263,7 +265,7 @@ class ManualPublishWorkflowIT extends BaseIT {
         // Unverify workflowversion
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, VERIFY, "--trs-id",
             "#workflow/github.com/DockstoreTestUser2/parameter_test_workflow", "--version-id", "master", "--file-path", "test.cwl.json",
-            "--descriptor-type", "cwl", "--platform", "Cromwell", "--platform-version", "thing", "--unverify", "--metadata",
+            "--descriptor-type", CWL.toString(), "--platform", "Cromwell", "--platform-version", "thing", "--unverify", "--metadata",
             "Docker testing group", SCRIPT_FLAG });
 
         // Workflowversion should be unverified
@@ -282,7 +284,7 @@ class ManualPublishWorkflowIT extends BaseIT {
         Client.main(
             new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, MANUAL_PUBLISH, "--repository",
                 "hello-dockstore-workflow", "--organization", "DockstoreTestUser2", "--git-version-control", "github", "--workflow-name",
-                "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", "wdl", SCRIPT_FLAG });
+                "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", WDL.toString(), SCRIPT_FLAG });
 
         // info (no version)
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, INFO, ENTRY,
@@ -310,8 +312,8 @@ class ManualPublishWorkflowIT extends BaseIT {
         Client.main(
             new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, MANUAL_PUBLISH, "--repository",
                 "hello-dockstore-workflow", "--organization", "DockstoreTestUser2", "--git-version-control", "github", "--workflow-name",
-                "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", "wdl", SCRIPT_FLAG });
-        Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, "wdl", ENTRY,
+                "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", WDL.toString(), SCRIPT_FLAG });
+        Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, WDL.toString(), ENTRY,
             SourceControl.GITHUB + "/DockstoreTestUser2/hello-dockstore-workflow/testname:testBoth", SCRIPT_FLAG });
     }
 
@@ -323,7 +325,7 @@ class ManualPublishWorkflowIT extends BaseIT {
         int exitCode = catchSystemExit(() ->  Client.main(
                 new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, MANUAL_PUBLISH, "--repository",
                         "dockstore_empty_repo", "--organization", "DockstoreTestUser2", "--git-version-control", "github", "--workflow-name",
-                        "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", "wdl", SCRIPT_FLAG }));
+                        "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", WDL.toString(), SCRIPT_FLAG }));
         assertEquals(Client.API_ERROR, exitCode);
     }
 
@@ -336,7 +338,7 @@ class ManualPublishWorkflowIT extends BaseIT {
         Client.main(
             new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, MANUAL_PUBLISH, "--repository",
                 "hello-dockstore-workflow", "--organization", "DockstoreTestUser2", "--git-version-control", "github", "--workflow-path",
-                "/Dockstore.wdl", "--descriptor-type", "wdl", SCRIPT_FLAG });
+                "/Dockstore.wdl", "--descriptor-type", WDL.toString(), SCRIPT_FLAG });
 
         // add labels
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, LABEL, ENTRY,
@@ -363,9 +365,9 @@ class ManualPublishWorkflowIT extends BaseIT {
         Client.main(
             new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, MANUAL_PUBLISH, "--repository",
                 "hello-dockstore-workflow", "--organization", "DockstoreTestUser2", "--git-version-control", "github", "--workflow-name",
-                "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", "wdl", SCRIPT_FLAG });
+                "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", WDL.toString(), SCRIPT_FLAG });
 
-        int exitCode = catchSystemExit(() ->  Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, "cwl", ENTRY,
+        int exitCode = catchSystemExit(() ->  Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, CWL.toString(), ENTRY,
                 SourceControl.GITHUB + "/DockstoreTestUser2/hello-dockstore-workflow/testname:testBoth", SCRIPT_FLAG }));
         assertEquals(Client.API_ERROR, exitCode);
     }

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/SingularityIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/SingularityIT.java
@@ -27,6 +27,8 @@ import static io.dockstore.client.cli.Client.CONFIG;
 import static io.dockstore.client.cli.Client.WORKFLOW;
 import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
 import static io.dockstore.client.cli.nested.WesCommandParser.JSON;
+import static io.dockstore.common.DescriptorLanguage.CWL;
+import static io.dockstore.common.DescriptorLanguage.WDL;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(SingularityTest.NAME)
@@ -59,7 +61,7 @@ class SingularityIT extends BaseIT {
         final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
         Workflow workflow = workflowApi.manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker",
-                "/checker-workflow-wrapping-workflow.cwl", "test", "cwl", null);
+                "/checker-workflow-wrapping-workflow.cwl", "test", CWL.toString(), null);
         workflowApi.refresh(workflow.getId(), true);
 
         // run the md5sum-checker workflow
@@ -82,7 +84,7 @@ class SingularityIT extends BaseIT {
         final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
         Workflow workflow = workflowApi.manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker",
-                "/checker-workflow-wrapping-workflow.wdl", "test", "wdl", null);
+                "/checker-workflow-wrapping-workflow.wdl", "test", WDL.toString(), null);
         workflowApi.refresh(workflow.getId(), true);
 
         // make a tmp copy of the dockstore config and add the cromwell conf file option to it

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/StarIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/StarIT.java
@@ -1,6 +1,7 @@
 package io.dockstore.client.cli;
 
 import io.dockstore.common.CLICommonTestUtilities;
+import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.SourceControl;
 import io.dropwizard.testing.ResourceHelpers;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,7 +42,7 @@ class StarIT extends BaseIT {
         Client.main(
             new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, MANUAL_PUBLISH, "--repository",
                 "hello-dockstore-workflow", "--organization", "DockstoreTestUser2", "--git-version-control", "github", "--workflow-name",
-                "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", "wdl", SCRIPT_FLAG });
+                "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", DescriptorLanguage.WDL.toString(), SCRIPT_FLAG });
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, PUBLISH, ENTRY,
             SourceControl.GITHUB + "/DockstoreTestUser2/hello-dockstore-workflow/testname", "--pub", SCRIPT_FLAG });
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, STAR, ENTRY,

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/StarIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/StarIT.java
@@ -1,7 +1,6 @@
 package io.dockstore.client.cli;
 
 import io.dockstore.common.CLICommonTestUtilities;
-import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.SourceControl;
 import io.dropwizard.testing.ResourceHelpers;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,6 +16,7 @@ import static io.dockstore.client.cli.nested.AbstractEntryClient.MANUAL_PUBLISH;
 import static io.dockstore.client.cli.nested.AbstractEntryClient.PUBLISH;
 import static io.dockstore.client.cli.nested.AbstractEntryClient.STAR;
 import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
+import static io.dockstore.common.DescriptorLanguage.WDL;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -42,7 +42,7 @@ class StarIT extends BaseIT {
         Client.main(
             new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, MANUAL_PUBLISH, "--repository",
                 "hello-dockstore-workflow", "--organization", "DockstoreTestUser2", "--git-version-control", "github", "--workflow-name",
-                "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", DescriptorLanguage.WDL.toString(), SCRIPT_FLAG });
+                "testname", "--workflow-path", "/Dockstore.wdl", "--descriptor-type", WDL.toString(), SCRIPT_FLAG });
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, PUBLISH, ENTRY,
             SourceControl.GITHUB + "/DockstoreTestUser2/hello-dockstore-workflow/testname", "--pub", SCRIPT_FLAG });
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("config_file2.txt"), WORKFLOW, STAR, ENTRY,

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WDLWorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WDLWorkflowIT.java
@@ -51,6 +51,7 @@ import static io.dockstore.client.cli.Client.WORKFLOW;
 import static io.dockstore.client.cli.nested.AbstractEntryClient.ENTRY_2_JSON;
 import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
 import static io.dockstore.client.cli.nested.WesCommandParser.JSON;
+import static io.dockstore.common.DescriptorLanguage.WDL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -91,7 +92,7 @@ class WDLWorkflowIT extends BaseIT {
         final ApiClient webClient = getWebClient(USER_1_USERNAME, testingPostgres);
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
         Workflow workflow = workflowApi
-            .manualRegister(SourceControl.GITHUB.getFriendlyName(), UNIFIED_WORKFLOW_REPO, "/checker.wdl", "", "wdl", "/md5sum.wdl.json");
+            .manualRegister(SourceControl.GITHUB.getFriendlyName(), UNIFIED_WORKFLOW_REPO, "/checker.wdl", "", WDL.toString(), "/md5sum.wdl.json");
         Workflow refresh = workflowApi.refresh(workflow.getId(), true);
         final PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
         workflowApi.publish(refresh.getId(), publishRequest);
@@ -124,7 +125,7 @@ class WDLWorkflowIT extends BaseIT {
         final ApiClient webClient = getWebClient(USER_1_USERNAME, testingPostgres);
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
         Workflow workflow = workflowApi.manualRegister(SourceControl.GITHUB.getFriendlyName(), SKYLAB_WORKFLOW_REPO,
-            "/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl", "", "wdl", null);
+            "/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl", "", WDL.toString(), null);
         Workflow refresh = workflowApi.refresh(workflow.getId(), true);
         final PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
         workflowApi.publish(refresh.getId(), publishRequest);
@@ -140,13 +141,13 @@ class WDLWorkflowIT extends BaseIT {
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
         // register underlying workflow
         Workflow workflow = workflowApi.manualRegister(SourceControl.GITHUB.getFriendlyName(), SKYLAB_WORKFLOW_REPO,
-            "/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl", "", "wdl", null);
+            "/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl", "", WDL.toString(), null);
         Workflow refresh = workflowApi.refresh(workflow.getId(), true);
         final PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
         workflowApi.publish(refresh.getId(), publishRequest);
         // register checker workflow
         Entry checkerWorkflow = workflowApi
-            .registerCheckerWorkflow("/test/smartseq2_single_sample/pr/test_smartseq2_single_sample_PR.wdl", workflow.getId(), "wdl",
+            .registerCheckerWorkflow("/test/smartseq2_single_sample/pr/test_smartseq2_single_sample_PR.wdl", workflow.getId(), WDL.toString(),
                 "/test/smartseq2_single_sample/pr/dockstore_test_inputs.json");
         workflowApi.refresh(checkerWorkflow.getId(), true);
         checkOnConvert(SKYLAB_WORKFLOW_CHECKER, "feature/upperThingy", "TestSmartSeq2SingleCellPR");

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -100,7 +100,7 @@ class WorkflowIT extends BaseIT {
         final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
         Workflow workflow = workflowApi.manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker",
-            "/checker-workflow-wrapping-workflow.cwl", "test", "cwl", null);
+            "/checker-workflow-wrapping-workflow.cwl", "test", CWL.toString(), null);
         assertEquals(1, workflow.getUsers().size(), "There should be one user of the workflow after manually registering it.");
         Workflow refresh = workflowApi.refresh(workflow.getId(), true);
 
@@ -131,7 +131,7 @@ class WorkflowIT extends BaseIT {
         // Register and refresh workflow
         Workflow workflow = workflowApi
             .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
-                "test", "cwl", null);
+                "test", CWL.toString(), null);
         Workflow refresh = workflowApi.refresh(workflow.getId(), true);
         Long workflowId = refresh.getId();
         WorkflowVersion workflowVersion = refresh.getWorkflowVersions().get(0);
@@ -202,10 +202,10 @@ class WorkflowIT extends BaseIT {
 
         Workflow workflow = workflowApi
             .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
-                "test", "cwl", null);
+                "test", CWL.toString(), null);
         Workflow refresh = workflowApi.refresh(workflow.getId(), true);
         assertFalse(refresh.isIsPublished());
-        workflowApi.registerCheckerWorkflow("checker-workflow-wrapping-workflow.cwl", workflow.getId(), "cwl", "checker-input-cwl.json");
+        workflowApi.registerCheckerWorkflow("checker-workflow-wrapping-workflow.cwl", workflow.getId(), CWL.toString(), "checker-input-cwl.json");
         workflowApi.refresh(workflow.getId(), true);
 
         final String fileWithIncorrectCredentials = ResourceHelpers.resourceFilePath("config_file.txt");
@@ -245,11 +245,11 @@ class WorkflowIT extends BaseIT {
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
         Workflow workflow = workflowApi
             .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
-                "test", "cwl", null);
+                "test", CWL.toString(), null);
         Workflow refresh = workflowApi.refresh(workflow.getId(), true);
         assertFalse(refresh.isIsPublished());
 
-        workflowApi.registerCheckerWorkflow("/checker-workflow-wrapping-workflow.cwl", workflow.getId(), "cwl", "checker-input-cwl.json");
+        workflowApi.registerCheckerWorkflow("/checker-workflow-wrapping-workflow.cwl", workflow.getId(), CWL.toString(), "checker-input-cwl.json");
 
         workflowApi.refresh(workflow.getId(), true);
 
@@ -345,7 +345,7 @@ class WorkflowIT extends BaseIT {
     void cwlVersion11() {
         final ApiClient userApiClient = CLICommonTestUtilities.getWebClient(true, USER_2_USERNAME, testingPostgres);
         WorkflowsApi userWorkflowsApi = new WorkflowsApi(userApiClient);
-        userWorkflowsApi.manualRegister("github", "dockstore-testing/Workflows-For-CI", "/cwl/v1.1/metadata.cwl", "metadata", "cwl",
+        userWorkflowsApi.manualRegister("github", "dockstore-testing/Workflows-For-CI", "/cwl/v1.1/metadata.cwl", "metadata", CWL.toString(),
             "/cwl/v1.1/cat-job.json");
         final Workflow workflowByPathGithub = userWorkflowsApi
             .getWorkflowByPath("github.com/dockstore-testing/Workflows-For-CI/metadata", WorkflowClient.BIOWORKFLOW, null);
@@ -373,7 +373,7 @@ class WorkflowIT extends BaseIT {
         assertFalse(workflowVersion.isValid());
 
         userWorkflowsApi
-            .manualRegister("github", "dockstore-testing/Workflows-For-CI", "/cwl/v1.1/count-lines1-wf.cwl", "count-lines1-wf", "cwl",
+            .manualRegister("github", "dockstore-testing/Workflows-For-CI", "/cwl/v1.1/count-lines1-wf.cwl", "count-lines1-wf", CWL.toString(),
                 "/cwl/v1.1/wc-job.json");
         final Workflow workflowByPathGithub2 = userWorkflowsApi
             .getWorkflowByPath("github.com/dockstore-testing/Workflows-For-CI/count-lines1-wf", WorkflowClient.BIOWORKFLOW, null);

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/CheckerClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/CheckerClient.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import io.dockstore.client.cli.nested.WorkflowClient;
-import io.dockstore.common.DescriptorLanguage;
 import io.swagger.client.ApiException;
 import io.swagger.client.api.UsersApi;
 import io.swagger.client.api.WorkflowsApi;
@@ -37,6 +36,8 @@ import static io.dockstore.client.cli.Client.VERSION;
 import static io.dockstore.client.cli.Client.WORKFLOW;
 import static io.dockstore.client.cli.Client.getGeneralFlags;
 import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
+import static io.dockstore.common.DescriptorLanguage.CWL;
+import static io.dockstore.common.DescriptorLanguage.WDL;
 import static java.lang.String.join;
 
 /**
@@ -130,12 +131,12 @@ public class CheckerClient extends WorkflowClient {
         } else {
             // Retrieve arguments
             String entryPath = reqVal(args, ENTRY);
-            final String descriptorType = optVal(args, "--descriptor-type", DescriptorLanguage.CWL.toString()).toUpperCase();
+            final String descriptorType = optVal(args, "--descriptor-type", CWL.toString()).toUpperCase();
             String descriptorPath = reqVal(args, "--descriptor-path");
             String inputParameterPath = optVal(args, "--input-parameter-path", null);
 
             // Check that descriptor type is valid
-            if (!DescriptorLanguage.CWL.toString().equals(descriptorType) && !DescriptorLanguage.WDL.toString().equals(descriptorType)) {
+            if (!CWL.toString().equals(descriptorType) && !WDL.toString().equals(descriptorType)) {
                 errorMessage("The given descriptor type " + descriptorType + " is not valid.",
                     Client.CLIENT_ERROR);
             }
@@ -177,7 +178,7 @@ public class CheckerClient extends WorkflowClient {
         out("");
         out("Required Parameters:");
         out("  " + ENTRY + " <entry>                                                          Complete entry path in the Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
-        out("  --descriptor-type <descriptor-type>                                      " + DescriptorLanguage.CWL.toString() + "/" + DescriptorLanguage.WDL.toString() + ", defaults to " + DescriptorLanguage.CWL.toString());
+        out("  --descriptor-type <descriptor-type>                                      " + CWL + "/" + WDL + ", defaults to " + CWL);
         out("  --descriptor-path <descriptor-path>                                      Path to the main descriptor file.");
         out("");
         out("Optional Parameters:");

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -241,7 +241,7 @@ public abstract class AbstractEntryClient<T> {
         out("");
         out("  " + CONVERT + "          :  utilities that allow you to " + CONVERT + " file types");
         out("");
-        out("  " + CWL.toString() + "              :  returns the Common Workflow Language " + getEntryType() + " definition for this entry");
+        out("  " + CWL + "              :  returns the Common Workflow Language " + getEntryType() + " definition for this entry");
         out("                      which enables integration with Global Alliance compliant systems");
         out("");
         out("  " + DOWNLOAD + "         :  " + DOWNLOAD + " " + getEntryType() + "s to the local directory");
@@ -1768,7 +1768,7 @@ public abstract class AbstractEntryClient<T> {
                 + " path in Dockstore (ex. quay.io/collaboratory/seqware-bwa-workflow)");
         out("  " + VERSION + " <version>                                                      " + getEntryType() + " version name");
         if (getEntryType().equalsIgnoreCase(TOOL)) {
-            out("  --descriptor-type <descriptor-type>                                      " + DescriptorLanguage.CWL.toString() + "/" + DescriptorLanguage.WDL.toString());
+            out("  --descriptor-type <descriptor-type>                                      " + CWL + "/" + WDL);
         }
         out("");
         out("Optional Parameters:");

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -268,7 +268,7 @@ public abstract class AbstractEntryClient<T> {
         out("");
         out("  " + TEST_PARAMETER + "   :  updates test parameter files for a version of a " + getEntryType() + "");
         out("");
-        out("  " + WDL.toString() + "              :  returns the Workflow Descriptor Language definition for this entry");
+        out("  " + WDL + "              :  returns the Workflow Descriptor Language definition for this entry");
         if (WORKFLOW.equalsIgnoreCase(getEntryType())) {
             out("");
             out("  " + WES + "              :  calls a Workflow Execution Schema API (WES) for a version of a " + getEntryType() + "");

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/CromwellLauncher.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/CromwellLauncher.java
@@ -27,6 +27,7 @@ import wdl.draft3.parser.WdlParser;
 
 import static io.dockstore.client.cli.ArgumentUtility.errorMessage;
 import static io.dockstore.client.cli.Client.IO_ERROR;
+import static io.dockstore.common.DescriptorLanguage.CWL;
 
 /**
  * This is a base class for clients that launch workflows with Cromwell
@@ -107,8 +108,8 @@ public class CromwellLauncher extends BaseLauncher {
         // There are currently issues with Cromwell 44 automatic type detection.  If it's CWL, the flag must be added.
         // https://github.com/broadinstitute/cromwell/issues/5085
         // Remove these 3 lines once the type can be detected again.
-        if (languageType == DescriptorLanguage.CWL) {
-            Collections.addAll(arguments, "--type", "cwl");
+        if (languageType == CWL) {
+            Collections.addAll(arguments, "--type", CWL.toString());
         }
 
         if (cromwellExtraParameters.size() > 0) {
@@ -128,7 +129,7 @@ public class CromwellLauncher extends BaseLauncher {
     public void provisionOutputFiles(String stdout, String stderr, String wdlOutputTarget) {
         if (Objects.equals(languageType, DescriptorLanguage.WDL)) {
             handleWDLOutputProvisioning(stdout, stderr, wdlOutputTarget);
-        } else if (Objects.equals(languageType, DescriptorLanguage.CWL)) {
+        } else if (Objects.equals(languageType, CWL)) {
             handleCWLOutputProvisioning(stdout, stderr);
         }
     }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesLauncher.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WesLauncher.java
@@ -31,6 +31,7 @@ import static io.dockstore.client.cli.Client.IO_ERROR;
 import static io.dockstore.client.cli.nested.AbstractEntryClient.LOGS;
 import static io.dockstore.client.cli.nested.AbstractEntryClient.STATUS;
 import static io.dockstore.client.cli.nested.WesCommandParser.ID;
+import static io.dockstore.common.DescriptorLanguage.CWL;
 import static io.github.collaboratory.cwl.CWLClient.WES;
 
 public final class WesLauncher {
@@ -324,7 +325,7 @@ public final class WesLauncher {
      * @return A String type
      */
     public static String createWorkflowTypeVersion(String workflowType) {
-        return "CWL".equalsIgnoreCase(workflowType) ? "v" + WORKFLOW_TYPE_VERSION : WORKFLOW_TYPE_VERSION;
+        return CWL.toString().equalsIgnoreCase(workflowType) ? "v" + WORKFLOW_TYPE_VERSION : WORKFLOW_TYPE_VERSION;
     }
 
     /**

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -95,6 +95,8 @@ import static io.dockstore.client.cli.JCommanderUtility.printJCommanderHelp;
 import static io.dockstore.client.cli.nested.ToolClient.VERSION_TAG;
 import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
 import static io.dockstore.client.cli.nested.WesCommandParser.JSON;
+import static io.dockstore.common.DescriptorLanguage.CWL;
+import static io.dockstore.common.DescriptorLanguage.WDL;
 import static java.lang.String.join;
 
 /**
@@ -171,7 +173,7 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
         out("Optional parameters:");
         out("  --workflow-path <workflow-path>                      Path for the descriptor file, defaults to /Dockstore.cwl");
         out("  --workflow-name <workflow-name>                      Workflow name, defaults to null");
-        out("  --descriptor-type <descriptor-type>                  Descriptor type, defaults to " + DescriptorLanguage.CWL);
+        out("  --descriptor-type <descriptor-type>                  Descriptor type, defaults to " + CWL);
         out("  --test-parameter-path <test-parameter-path>          Path to default test parameter file, defaults to /test.json");
 
         printHelpFooter();
@@ -944,11 +946,11 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
             final String gitVersionControl = reqVal(args, "--git-version-control");
 
             final String workflowPath = optVal(args, "--workflow-path", "/Dockstore.cwl");
-            final String descriptorType = optVal(args, "--descriptor-type", DescriptorLanguage.CWL.toString()).toUpperCase();
+            final String descriptorType = optVal(args, "--descriptor-type", CWL.toString()).toUpperCase();
             final String testParameterFile = optVal(args, "--test-parameter-path", "/test.json");
 
             // Check if valid input
-            if (!DescriptorLanguage.CWL.toString().equals(descriptorType) && !DescriptorLanguage.WDL.toString().equals(descriptorType)) {
+            if (!CWL.toString().equals(descriptorType) && !WDL.toString().equals(descriptorType)) {
                 errorMessage("Please ensure that the descriptor type is either cwl or wdl.", Client.CLIENT_ERROR);
             }
 
@@ -1035,7 +1037,7 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
                 if (workflow.getMode() == io.swagger.client.model.Workflow.ModeEnum.STUB) {
 
                     // Check if valid input
-                    if (!"cwl".equalsIgnoreCase(descriptorType) && !"wdl".equalsIgnoreCase(descriptorType)) {
+                    if (!CWL.toString().equalsIgnoreCase(descriptorType) && !WDL.toString().equalsIgnoreCase(descriptorType)) {
                         errorMessage("Please ensure that the descriptor type is either cwl or wdl.", Client.CLIENT_ERROR);
                     }
 


### PR DESCRIPTION
**Description**
Whilst doing this [PR](https://github.com/dockstore/dockstore-cli/pull/231) I noticed that the strings `"WDL"` and `"CWL"` show up a lot in the CLI. So, this PR moves `"WDL"` and `"CWL"` to constants.

The constants that I am using (which I got from `io.dockstore.common.DescriptorLanguage`), have `WDL` and `CWL` capitalized. This not an issue, as our code permits any case to be used when dealing with the commands `CWL` and `WDL`. Also, if this was an issue, I imagine it would be picked up by our tests.

**Review Instructions**
Ensure that all tests run correctly.

**Issue**
I stated that I would do this in this [comment](https://github.com/dockstore/dockstore-cli/pull/231#discussion_r1134237050).

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [X] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [X] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
