### PR TITLE
DOCK-2349: added error handling message for CWL JSON conversion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,13 +325,9 @@ commands:
      - run:
          name: Install postgresql client
          command: |
-           sudo rm -rf /var/lib/apt/lists/*
-           # heroku.com is not updating their keys
-           # https://github.com/heroku/cli/issues/1464
-           curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
+           # https://discuss.circleci.com/t/heroku-gpg-issues-in-ubuntu-images/43834/3
+           sudo rm -Rf /etc/apt/sources.list.d/heroku.list
            sudo apt update
-           # NOTE: this may be installing latest client; perhaps should
-           # specify version
            sudo apt install -y postgresql-client
 
   setup_for_unit_tests:

--- a/dockstore-client/src/main/java/io/github/collaboratory/cwl/CWLClient.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/cwl/CWLClient.java
@@ -452,7 +452,7 @@ public class CWLClient extends BaseLanguageClient implements LanguageClientInter
             return null;
         } catch (ClassCastException ex) {
             errorMessage("Cannot generate a JSON for this workflow.\n"
-                    + "The structure of its input is currently not supported. Please provide items as a String.", GENERIC_ERROR);
+                    + "The structure of its input is currently not supported. Please provide type and items as a string.", GENERIC_ERROR);
         }
         return null;
     }

--- a/dockstore-client/src/main/java/io/github/collaboratory/cwl/CWLClient.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/cwl/CWLClient.java
@@ -408,7 +408,7 @@ public class CWLClient extends BaseLanguageClient implements LanguageClientInter
         final File tempDir = Files.createTempDir();
         final File primaryFile = abstractEntryClient.downloadTargetEntry(entry, ToolDescriptor.TypeEnum.CWL, true, tempDir);
         try {
-            createInputJson(primaryFile, json);
+            return createInputJson(primaryFile, json);
         } catch (ClassCastException ex) {
             errorMessage("Cannot generate a JSON for this workflow.\n"
                     + "The structure of its input is currently not supported. Please provide type and items as a string.", GENERIC_ERROR);

--- a/dockstore-client/src/main/java/io/github/collaboratory/cwl/CWLClient.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/cwl/CWLClient.java
@@ -407,52 +407,55 @@ public class CWLClient extends BaseLanguageClient implements LanguageClientInter
     public String generateInputJson(String entry, final boolean json) throws ApiException, IOException {
         final File tempDir = Files.createTempDir();
         final File primaryFile = abstractEntryClient.downloadTargetEntry(entry, ToolDescriptor.TypeEnum.CWL, true, tempDir);
-
         try {
-            // need to suppress output
-            final ImmutablePair<String, String> output = abstractEntryClient.getCwlUtil().parseCWL(primaryFile.getAbsolutePath());
-            final Map<String, Object> stringObjectMap = abstractEntryClient.getCwlUtil().extractRunJson(output.getLeft());
-            if (json) {
-                try {
-                    return gson.toJson(stringObjectMap);
-                } catch (CWL.GsonBuildException ex) {
-                    exceptionMessage(ex, "There was an error creating the CWL GSON instance.", API_ERROR);
-                } catch (JsonParseException ex) {
-                    exceptionMessage(ex, "The JSON file provided is invalid.", API_ERROR);
-                }
-            } else {
-                // re-arrange as rows and columns
-                final Map<String, String> typeMap = abstractEntryClient.getCwlUtil().extractCWLTypes(output.getLeft());
-                final List<String> headers = new ArrayList<>();
-                final List<String> types = new ArrayList<>();
-                final List<String> entries = new ArrayList<>();
-                for (final Map.Entry<String, Object> objectEntry : stringObjectMap.entrySet()) {
-                    headers.add(objectEntry.getKey());
-                    types.add(typeMap.get(objectEntry.getKey()));
-                    Object value = objectEntry.getValue();
-                    if (value instanceof Map) {
-                        Map map = (Map)value;
-                        if (map.containsKey("class") && "File".equals(map.get("class"))) {
-                            value = map.get("path");
-                        }
-
-                    }
-                    entries.add(value.toString());
-                }
-                final StringBuffer buffer = new StringBuffer();
-                try (CSVPrinter printer = new CSVPrinter(buffer, CSVFormat.DEFAULT)) {
-                    printer.printRecord(headers);
-                    printer.printComment("do not edit the following row, describes CWL types");
-                    printer.printRecord(types);
-                    printer.printComment("duplicate the following row and fill in the values for each run you wish to set parameters for");
-                    printer.printRecord(entries);
-                }
-                return buffer.toString();
-            }
-            return null;
+            createInputJson(primaryFile, json);
         } catch (ClassCastException ex) {
             errorMessage("Cannot generate a JSON for this workflow.\n"
                     + "The structure of its input is currently not supported. Please provide type and items as a string.", GENERIC_ERROR);
+        }
+        return null;
+    }
+
+    private String createInputJson(File primaryFile, final boolean json) throws ApiException, IOException {
+        // need to suppress output
+        final ImmutablePair<String, String> output = abstractEntryClient.getCwlUtil().parseCWL(primaryFile.getAbsolutePath());
+        final Map<String, Object> stringObjectMap = abstractEntryClient.getCwlUtil().extractRunJson(output.getLeft());
+        if (json) {
+            try {
+                return gson.toJson(stringObjectMap);
+            } catch (CWL.GsonBuildException ex) {
+                exceptionMessage(ex, "There was an error creating the CWL GSON instance.", API_ERROR);
+            } catch (JsonParseException ex) {
+                exceptionMessage(ex, "The JSON file provided is invalid.", API_ERROR);
+            }
+        } else {
+            // re-arrange as rows and columns
+            final Map<String, String> typeMap = abstractEntryClient.getCwlUtil().extractCWLTypes(output.getLeft());
+            final List<String> headers = new ArrayList<>();
+            final List<String> types = new ArrayList<>();
+            final List<String> entries = new ArrayList<>();
+            for (final Map.Entry<String, Object> objectEntry : stringObjectMap.entrySet()) {
+                headers.add(objectEntry.getKey());
+                types.add(typeMap.get(objectEntry.getKey()));
+                Object value = objectEntry.getValue();
+                if (value instanceof Map) {
+                    Map map = (Map)value;
+                    if (map.containsKey("class") && "File".equals(map.get("class"))) {
+                        value = map.get("path");
+                    }
+
+                }
+                entries.add(value.toString());
+            }
+            final StringBuffer buffer = new StringBuffer();
+            try (CSVPrinter printer = new CSVPrinter(buffer, CSVFormat.DEFAULT)) {
+                printer.printRecord(headers);
+                printer.printComment("do not edit the following row, describes CWL types");
+                printer.printRecord(types);
+                printer.printComment("duplicate the following row and fill in the values for each run you wish to set parameters for");
+                printer.printRecord(entries);
+            }
+            return buffer.toString();
         }
         return null;
     }

--- a/dockstore-client/src/main/java/io/github/collaboratory/cwl/CWLClient.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/cwl/CWLClient.java
@@ -452,7 +452,7 @@ public class CWLClient extends BaseLanguageClient implements LanguageClientInter
             return null;
         } catch (ClassCastException ex) {
             errorMessage("Cannot generate a JSON for this workflow.\n"
-                    + "The structure of its input is currently not supported. Please provide items as a String", GENERIC_ERROR);
+                    + "The structure of its input is currently not supported. Please provide items as a String.", GENERIC_ERROR);
         }
         return null;
     }

--- a/dockstore-client/src/main/java/io/github/collaboratory/cwl/CWLClient.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/cwl/CWLClient.java
@@ -452,7 +452,7 @@ public class CWLClient extends BaseLanguageClient implements LanguageClientInter
             return null;
         } catch (ClassCastException ex) {
             errorMessage("Cannot generate a JSON for this workflow.\n"
-                    + "The structure of its input is currently not supported", GENERIC_ERROR);
+                    + "The structure of its input is currently not supported. Please provide items as a String", GENERIC_ERROR);
         }
         return null;
     }


### PR DESCRIPTION
**Description**
Currently, generating test parameter JSON files for CWL workflows with arrays for `items` ([example](https://qa.dockstore.org/workflows/github.com/bcbio/bcbio_validation_workflows/wes-agha-test-gcp:master?tab=files)) results in a `ClassCastException` error due to these [lines](https://github.com/dockstore/cwlavro/blob/83e0bd298060472bea42d638460c5899a67380d0/cwlavro-tools/src/main/java/io/cwl/avro/CWL.java#L307-L308).

This PR adds an error handling message to let users know that it's file structure is not supported yet. 

Before fix: 
```
dockstore workflow convert entry2json --entry github.com/bcbio/bcbio_validation_workflows/wes-agha-test-gcp:master
Current version : 1.13.1
You have the most recent stable release.
If you wish to upgrade to the latest unstable version, please use the following command:
   dockstore --upgrade-unstable
14:37:29.011 [main] ERROR io.dockstore.client.cli.ArgumentUtility - java.lang.ClassCastException: class java.util.ArrayList cannot be cast to class java.lang.String (java.util.ArrayList and java.lang.String are in module java.base of loader 'bootstrap')
	at io.cwl.avro.CWL.getStub(CWL.java:307)
	at io.cwl.avro.CWL.extractRunJson(CWL.java:138)
	at io.github.collaboratory.cwl.CWLClient.generateInputJson(CWLClient.java:411)
	at io.dockstore.client.cli.nested.WorkflowClient.convertWorkflow2Json(WorkflowClient.java:289)
	at io.dockstore.client.cli.nested.WorkflowClient.handleEntry2json(WorkflowClient.java:273)
	at io.dockstore.client.cli.nested.AbstractEntryClient.convert(AbstractEntryClient.java:644)
	at io.dockstore.client.cli.nested.AbstractEntryClient.processEntryCommands(AbstractEntryClient.java:309)
	at io.dockstore.client.cli.Client.run(Client.java:737)
	at io.dockstore.client.cli.Client.main(Client.java:633)
```

After fix:
```
dockstore workflow convert entry2json --entry github.com/bcbio/bcbio_validation_workflows/wes-agha-test-gcp:master
ERROR: Cannot generate a JSON for this workflow.
The structure of its input is currently not supported. Please provide items as a String.
```
**Review Instructions**
Review that the new error message is shown.

**Issue**
https://github.com/dockstore/dockstore/issues/5418

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
