### PR TITLE
rename reports to avoid clash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,7 +495,7 @@ commands:
           name: Rename and move coverage reports
           command: |
             mkdir coverage
-            cp ./reports/target/site/jacoco-aggregate/jacoco.xml coverage/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}.xml
+            cp ./dockstore-cli-reports/target/site/jacoco-aggregate/jacoco.xml coverage/${CIRCLE_JOB}-${CIRCLE_NODE_INDEX}.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ dockstore-cli-integration-testing/target/
 dockstore-cli-integration-testing/cromwell-executions/
 dockstore-cli-integration-testing/cromwell-input/
 dockstore-cli-integration-testing/datastore/
-reports/target/
+dockstore-cli-reports/target/
 target
 
 # confidential testing files

--- a/dockstore-cli-reports/pom.xml
+++ b/dockstore-cli-reports/pom.xml
@@ -22,7 +22,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>reports</artifactId>
+    <artifactId>dockstore-cli-reports</artifactId>
     <!-- do not set packaging to pom, because otherwise we will receive "Not executing Javadoc as the project is not a Java classpath-capable package" -->
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
         <!-- this is not an aggregated path -->
         <sonar.coverage.jacoco.xmlReportPaths>
-            ${project.basedir}/target/jacoco.xml,${project.basedir}/target/jacoco-it.xml,${project.basedir}/../reports/target/site/jacoco-aggregate/jacoco.xml
+            ${project.basedir}/target/jacoco.xml,${project.basedir}/target/jacoco-it.xml,${project.basedir}/../dockstore-cli-reports/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <!-- end sonarcloud properties -->
         <cwlavro.version>2.0.4.7</cwlavro.version>
@@ -123,7 +123,7 @@
         <module>dockstore-client</module>
         <module>dockstore-cli-integration-testing</module>
         <module>support</module>
-        <module>reports</module>
+        <module>dockstore-cli-reports</module>
         <module>openapi-java-wes-client</module>
     </modules>
 


### PR DESCRIPTION
**Description**
Follow-up from https://github.com/dockstore/dockstore-support/pull/469
Noticed https://artifacts.oicr.on.ca/artifactory/collab-release/io/dockstore/reports/ had a mix of stuff from different projects (presumably missed since they aren't actually used for anything and the machine user doesn't have overwrite permissions)

**Review Instructions**
No change  to coverage information

**Issue**
n/a

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
