### PR TITLE
Remove wes checks that are never executed

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -191,7 +191,6 @@ public abstract class AbstractEntryClient<T> {
     boolean isLocalEntry = false;
     boolean ignoreChecksums = false;
 
-    private boolean isWesCommand = false;
     private WesRequestData wesRequestData = null;
 
     static String getCleanedDescription(String description) {
@@ -210,10 +209,6 @@ public abstract class AbstractEntryClient<T> {
 
     public void setWesRequestData(WesRequestData wrd) {
         this.wesRequestData = wrd;
-    }
-
-    public boolean isWesCommand() {
-        return isWesCommand;
     }
 
     boolean isLocalEntry() {
@@ -362,7 +357,6 @@ public abstract class AbstractEntryClient<T> {
                 testParameter(args);
                 break;
             case WES:
-                isWesCommand = true;
                 if (WORKFLOW.equalsIgnoreCase(getEntryType())) {
                     processWesCommands(args);
                 } else {

--- a/dockstore-client/src/main/java/io/github/collaboratory/cwl/CWLClient.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/cwl/CWLClient.java
@@ -114,14 +114,9 @@ public class CWLClient extends BaseLanguageClient implements LanguageClientInter
         super(abstractEntryClient, null);
 
         fileProvisioning = new FileProvisioning(abstractEntryClient.getConfigFile());
-
-        if (!abstractEntryClient.isWesCommand()) {
-            // Set the launcher
-            INIConfiguration config = Utilities.parseConfig(abstractEntryClient.getConfigFile());
-            cwlLauncherType = config.getString(CWL_RUNNER, DEFAULT_LAUNCHER);
-        } else {
-            cwlLauncherType = WES;
-        }
+        // Set the launcher
+        INIConfiguration config = Utilities.parseConfig(abstractEntryClient.getConfigFile());
+        cwlLauncherType = config.getString(CWL_RUNNER, DEFAULT_LAUNCHER);
 
         BaseLauncher launcher;
         switch (cwlLauncherType) {


### PR DESCRIPTION
**Description**
This PR removes the `isWesCommand()` invocations because the code is never executed. Charles' assessment in the issue is correct:

> if launching a workflow via WES, the CLI creates a WESLauncher, which doesn't instantiate a BaseLanguageClient subclass instance -- so the code never even executes for a WES launch.

Looking at the git blames, it appears that this code used to be executed when the language clients would do the WES launch: https://github.com/dockstore/dockstore/pull/2156. However, we eventually moved away from this model and abstracted the WES launch to be independent of the language clients because it doesn't need it https://github.com/dockstore/dockstore-cli/pull/100. The unexecuted WES checks are just code that never got removed when we abstracted the WES launch.

I did a sanity check and stepped through a test for `dockstore workflow wes launch` and it never went through the `BaseLanguageClient` code path. It diverges when processing the entry commands [here](https://github.com/dockstore/dockstore-cli/blob/1dca21fa74d66920c0a2548013c39a9adc9542a9/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java#L324), so WES commands go through `processWesCommands` and launch commands go through `launch` which invokes the language clients.

**Review Instructions**
Would say that it's not really reviewable because it's code cleanup of code that is never executed. Just check that tests are passing.

**Issue**
dockstore/dockstore#5503
https://ucsc-cgl.atlassian.net/browse/DOCK-2396

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
