### PR TITLE
new broad artifactory location

### DIFF
--- a/dockstore-cli-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-cli-integration-testing/generated/src/main/resources/pom.xml
@@ -139,7 +139,7 @@
       </snapshots>
       <id>artifactory.broadinstitute.org</id>
       <name>artifactory.broadinstitute.org</name>
-      <url>https://artifactory.broadinstitute.org/artifactory/libs-release</url>
+      <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
     </repository>
   </repositories>
 </project>

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/YamlClientIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/YamlClientIT.java
@@ -16,12 +16,9 @@
 
 package io.dockstore.client.cli;
 
-import static io.dockstore.client.cli.Client.CONFIG;
-import static io.dockstore.client.cli.Client.HELP;
-import static io.dockstore.client.cli.YamlVerifyUtility.MISSING_FILE_ERROR;
-import static io.dockstore.client.cli.YamlVerifyUtility.SERVICE_DOES_NOT_HAVE_FILES;
-import static io.dockstore.client.cli.YamlVerifyUtility.YAML;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.IOException;
+import java.util.ArrayList;
+
 import com.google.common.collect.Lists;
 import io.dockstore.common.CLICommonTestUtilities;
 import io.dockstore.common.TestUtility;
@@ -30,8 +27,13 @@ import org.junit.jupiter.api.Test;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.stream.SystemErr;
 import uk.org.webcompere.systemstubs.stream.SystemOut;
-import java.io.IOException;
-import java.util.ArrayList;
+
+import static io.dockstore.client.cli.Client.CONFIG;
+import static io.dockstore.client.cli.Client.HELP;
+import static io.dockstore.client.cli.YamlVerifyUtility.MISSING_FILE_ERROR;
+import static io.dockstore.client.cli.YamlVerifyUtility.SERVICE_DOES_NOT_HAVE_FILES;
+import static io.dockstore.client.cli.YamlVerifyUtility.YAML;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class YamlClientIT extends BaseIT {
 

--- a/dockstore-cli-reports/generated/src/main/resources/pom.xml
+++ b/dockstore-cli-reports/generated/src/main/resources/pom.xml
@@ -82,7 +82,7 @@
       </snapshots>
       <id>artifactory.broadinstitute.org</id>
       <name>artifactory.broadinstitute.org</name>
-      <url>https://artifactory.broadinstitute.org/artifactory/libs-release</url>
+      <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
     </repository>
   </repositories>
 </project>

--- a/dockstore-client/generated/src/main/resources/pom.xml
+++ b/dockstore-client/generated/src/main/resources/pom.xml
@@ -401,7 +401,7 @@
       </snapshots>
       <id>artifactory.broadinstitute.org</id>
       <name>artifactory.broadinstitute.org</name>
-      <url>https://artifactory.broadinstitute.org/artifactory/libs-release</url>
+      <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
     </repository>
   </repositories>
 </project>

--- a/dockstore-file-plugin-parent/generated/src/main/resources/pom.xml
+++ b/dockstore-file-plugin-parent/generated/src/main/resources/pom.xml
@@ -70,7 +70,7 @@
       </snapshots>
       <id>artifactory.broadinstitute.org</id>
       <name>artifactory.broadinstitute.org</name>
-      <url>https://artifactory.broadinstitute.org/artifactory/libs-release</url>
+      <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
     </repository>
   </repositories>
 </project>

--- a/openapi-java-wes-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-wes-client/generated/src/main/resources/pom.xml
@@ -124,7 +124,7 @@
       </snapshots>
       <id>artifactory.broadinstitute.org</id>
       <name>artifactory.broadinstitute.org</name>
-      <url>https://artifactory.broadinstitute.org/artifactory/libs-release</url>
+      <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
     </repository>
   </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <repository>
             <id>artifactory.broadinstitute.org</id>
             <name>artifactory.broadinstitute.org</name>
-            <url>https://artifactory.broadinstitute.org/artifactory/libs-release</url>
+	    <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/support/generated/src/main/resources/pom.xml
+++ b/support/generated/src/main/resources/pom.xml
@@ -112,7 +112,7 @@
       </snapshots>
       <id>artifactory.broadinstitute.org</id>
       <name>artifactory.broadinstitute.org</name>
-      <url>https://artifactory.broadinstitute.org/artifactory/libs-release</url>
+      <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
     </repository>
   </repositories>
 </project>


### PR DESCRIPTION
**Description**
Has been tripping up the nightly compatibility (with the webservice) builds. 
Broad artifactory has moved and gives out corrupted info with a redirect if we point at the wrong URL

**Review Instructions**
Nightly cron build should work
https://github.com/dockstore/dockstore-cli/actions/workflows/cron.yml

**Issue**
n/a

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
