### PR TITLE
DOCK-2323: Log source and destination paths for file provisioning

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/common/FileProvisioning.java
+++ b/dockstore-client/src/main/java/io/dockstore/common/FileProvisioning.java
@@ -147,8 +147,7 @@ public class FileProvisioning {
     }
 
     private static void printSourceAndDestination(String sourcePath, Path destinationPath) {
-        System.out.println("Source path: " + sourcePath);
-        System.out.println("Destination path: " + destinationPath);
+        System.out.println("Saving " + sourcePath  + " to " + destinationPath);
     }
 
     /*

--- a/dockstore-client/src/main/java/io/dockstore/common/FileProvisioning.java
+++ b/dockstore-client/src/main/java/io/dockstore/common/FileProvisioning.java
@@ -146,6 +146,11 @@ public class FileProvisioning {
         return "true".equalsIgnoreCase(useCache) || "use".equalsIgnoreCase(useCache) || "T".equalsIgnoreCase(useCache);
     }
 
+    private static void printSourceAndDestination(String sourcePath, Path destinationPath) {
+        System.out.println("Source path: " + sourcePath);
+        System.out.println("Destination path: " + destinationPath);
+    }
+
     /*
      * Retrieves plugin name given object class name.
      * Splits outer plugin class name (which extends Plugin abstract class) and inner class name (which extends
@@ -661,6 +666,7 @@ public class FileProvisioning {
 
         @Override
         public boolean downloadFrom(String sourcePath, Path destination) {
+            printSourceAndDestination(sourcePath, destination);
             return FileProvisionUtil.downloadFromVFS2(sourcePath, destination, threads);
         }
 


### PR DESCRIPTION
**Description**
This PR allows file provisioning to display source and destination paths.

**Review Instructions**
1. Remove ~/.dockstore/libraries/
2. Run dockstore workflow launch --entry github.com/dockstore-testing/Metaphlan-WDL:master and see cromwell download with the source and destination path logged like below.
```
> dockstore workflow launch --entry github.com/dockstore-testing/Metaphlan-WDL:master 
WARNING: Docker is not running. If this workflow uses Docker, it will fail.
Saving https://github.com/broadinstitute/cromwell/releases/download/84/cromwell-84.jar to /home/nhyun/.dockstore/libraries/cromwell-84.jar
[##########################                        ] 53%

```

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2323

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
