### PR TITLE
Re-enable failing CLI Test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
       image: ubuntu-2204:2022.10.1
     environment:
       PGHOST: 127.0.0.1
-    resource_class: large
+    resource_class: medium
 
   toil_wes_test_executor:
     machine: # run the steps with Ubuntu VM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
       image: ubuntu-2204:2022.10.1
     environment:
       PGHOST: 127.0.0.1
-    resource_class: medium
+    resource_class: medium+
 
   toil_wes_test_executor:
     machine: # run the steps with Ubuntu VM
@@ -152,7 +152,7 @@ jobs:
           # Java can read cgroup. Sadly the cgroup in
           # CircleCI is wrong. Have to manually set. Nothing to do with surefire
           # plugin, it has its own JVM. The two of these must add up to a bit less than 4GB.
-          JAVA_TOOL_OPTIONS: -Xmx1024m
+          JAVA_TOOL_OPTIONS: -Xmx512m
     steps: # a collection of executable commands
       - checkout # check out source code to working directory
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
           # Java can read cgroup. Sadly the cgroup in
           # CircleCI is wrong. Have to manually set. Nothing to do with surefire
           # plugin, it has its own JVM. The two of these must add up to a bit less than 4GB.
-          JAVA_TOOL_OPTIONS: -Xmx512m
+          JAVA_TOOL_OPTIONS: -Xmx1024m
     steps: # a collection of executable commands
       - checkout # check out source code to working directory
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
       image: ubuntu-2204:2022.10.1
     environment:
       PGHOST: 127.0.0.1
-    resource_class: medium+
+    resource_class: large
 
   toil_wes_test_executor:
     machine: # run the steps with Ubuntu VM

--- a/dockstore-cli-integration-testing/pom.xml
+++ b/dockstore-cli-integration-testing/pom.xml
@@ -268,7 +268,7 @@
                         --add-opens java.base/java.base=ALL-UNNAMED
                         --add-opens java.base/java.lang.reflect=ALL-UNNAMED
                         --add-opens java.base/sun.nio.fs=ALL-UNNAMED
-                        -da:org.hibernate
+                        -da:org.hibernate...
                     </argLine>
                 </configuration>
             </plugin>

--- a/dockstore-cli-integration-testing/pom.xml
+++ b/dockstore-cli-integration-testing/pom.xml
@@ -257,6 +257,7 @@
                     <!-- seems like some form of Jackson fork issue for this module with random order -->
                     <runOrder>filesystem</runOrder>
                     <!-- workaround for Java 17 module issues with powermock -->
+                    <!-- Disable assertions for Hibernate package: https://ucsc-cgl.atlassian.net/browse/SEAB-5854 -->
                     <argLine>
                         @{argLine}
                         --illegal-access=permit
@@ -267,6 +268,7 @@
                         --add-opens java.base/java.base=ALL-UNNAMED
                         --add-opens java.base/java.lang.reflect=ALL-UNNAMED
                         --add-opens java.base/sun.nio.fs=ALL-UNNAMED
+                        --da org.hibernate
                     </argLine>
                 </configuration>
             </plugin>

--- a/dockstore-cli-integration-testing/pom.xml
+++ b/dockstore-cli-integration-testing/pom.xml
@@ -268,7 +268,8 @@
                         --add-opens java.base/java.base=ALL-UNNAMED
                         --add-opens java.base/java.lang.reflect=ALL-UNNAMED
                         --add-opens java.base/sun.nio.fs=ALL-UNNAMED
-                        --da org.hibernate
+                        -ea
+                        -da org.hibernate
                     </argLine>
                 </configuration>
             </plugin>

--- a/dockstore-cli-integration-testing/pom.xml
+++ b/dockstore-cli-integration-testing/pom.xml
@@ -253,11 +253,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
+                    <!-- Disable JVM assertions for now. See SEAB-5854 -->
+                    <enableAssertions>false</enableAssertions>
                     <skipTests>${skipITs}</skipTests>
                     <!-- seems like some form of Jackson fork issue for this module with random order -->
                     <runOrder>filesystem</runOrder>
                     <!-- workaround for Java 17 module issues with powermock -->
-                    <!-- Disable assertions for Hibernate package: https://ucsc-cgl.atlassian.net/browse/SEAB-5854 -->
                     <argLine>
                         @{argLine}
                         --illegal-access=permit
@@ -268,8 +269,6 @@
                         --add-opens java.base/java.base=ALL-UNNAMED
                         --add-opens java.base/java.lang.reflect=ALL-UNNAMED
                         --add-opens java.base/sun.nio.fs=ALL-UNNAMED
-                        -ea
-                        -da org.hibernate
                     </argLine>
                 </configuration>
             </plugin>

--- a/dockstore-cli-integration-testing/pom.xml
+++ b/dockstore-cli-integration-testing/pom.xml
@@ -253,12 +253,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-                    <!-- Disable JVM assertions for now. See SEAB-5854 -->
-                    <enableAssertions>false</enableAssertions>
                     <skipTests>${skipITs}</skipTests>
                     <!-- seems like some form of Jackson fork issue for this module with random order -->
                     <runOrder>filesystem</runOrder>
                     <!-- workaround for Java 17 module issues with powermock -->
+                    <!-- And Disable org.hibernate assertions for now. See SEAB-5854 -->
                     <argLine>
                         @{argLine}
                         --illegal-access=permit
@@ -269,6 +268,7 @@
                         --add-opens java.base/java.base=ALL-UNNAMED
                         --add-opens java.base/java.lang.reflect=ALL-UNNAMED
                         --add-opens java.base/sun.nio.fs=ALL-UNNAMED
+                        -da:org.hibernate
                     </argLine>
                 </configuration>
             </plugin>

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WDLWorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WDLWorkflowIT.java
@@ -25,7 +25,6 @@ import static io.dockstore.client.cli.nested.AbstractEntryClient.ENTRY_2_JSON;
 import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
 import static io.dockstore.client.cli.nested.WesCommandParser.JSON;
 import static io.dockstore.common.DescriptorLanguage.WDL;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.dockstore.common.CLICommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
@@ -41,24 +40,11 @@ import io.dockstore.openapi.client.model.WorkflowVersion;
 import io.dropwizard.testing.ResourceHelpers;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.stream.SystemErr;
 import uk.org.webcompere.systemstubs.stream.SystemOut;
-
-import static io.dockstore.client.cli.ArgumentUtility.CONVERT;
-import static io.dockstore.client.cli.ArgumentUtility.LAUNCH;
-import static io.dockstore.client.cli.Client.CONFIG;
-import static io.dockstore.client.cli.Client.SCRIPT_FLAG;
-import static io.dockstore.client.cli.Client.WORKFLOW;
-import static io.dockstore.client.cli.nested.AbstractEntryClient.ENTRY_2_JSON;
-import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
-import static io.dockstore.client.cli.nested.WesCommandParser.JSON;
-import static io.dockstore.common.DescriptorLanguage.WDL;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Gathers a few tests that focus on WDL workflows, testing things like generation of wdl test parameter files

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WDLWorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WDLWorkflowIT.java
@@ -16,13 +16,17 @@
 
 package io.dockstore.client.cli;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-
+import static io.dockstore.client.cli.ArgumentUtility.CONVERT;
+import static io.dockstore.client.cli.ArgumentUtility.LAUNCH;
+import static io.dockstore.client.cli.Client.CONFIG;
+import static io.dockstore.client.cli.Client.SCRIPT_FLAG;
+import static io.dockstore.client.cli.Client.WORKFLOW;
+import static io.dockstore.client.cli.nested.AbstractEntryClient.ENTRY_2_JSON;
+import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
+import static io.dockstore.client.cli.nested.WesCommandParser.JSON;
+import static io.dockstore.common.DescriptorLanguage.WDL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.dockstore.common.CLICommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
 import io.dockstore.common.SourceControl;
@@ -37,24 +41,17 @@ import io.dockstore.openapi.client.model.WorkflowVersion;
 import io.dropwizard.testing.ResourceHelpers;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.stream.SystemErr;
 import uk.org.webcompere.systemstubs.stream.SystemOut;
-
-import static io.dockstore.client.cli.ArgumentUtility.CONVERT;
-import static io.dockstore.client.cli.ArgumentUtility.LAUNCH;
-import static io.dockstore.client.cli.Client.CONFIG;
-import static io.dockstore.client.cli.Client.SCRIPT_FLAG;
-import static io.dockstore.client.cli.Client.WORKFLOW;
-import static io.dockstore.client.cli.nested.AbstractEntryClient.ENTRY_2_JSON;
-import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
-import static io.dockstore.client.cli.nested.WesCommandParser.JSON;
-import static io.dockstore.common.DescriptorLanguage.WDL;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Gathers a few tests that focus on WDL workflows, testing things like generation of wdl test parameter files
@@ -64,7 +61,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @Tag(ConfidentialTest.NAME)
 @Tag(WorkflowTest.NAME)
-@Disabled("unintended change in webservice 1.15 seems to have broken this")
 class WDLWorkflowIT extends BaseIT {
 
     // TODO: Remove extra tags and branches on skylab workflows which are not needed

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WDLWorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WDLWorkflowIT.java
@@ -25,6 +25,7 @@ import static io.dockstore.client.cli.nested.AbstractEntryClient.ENTRY_2_JSON;
 import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
 import static io.dockstore.client.cli.nested.WesCommandParser.JSON;
 import static io.dockstore.common.DescriptorLanguage.WDL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.dockstore.common.CLICommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
@@ -45,6 +46,12 @@ import org.junit.jupiter.api.Test;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.stream.SystemErr;
 import uk.org.webcompere.systemstubs.stream.SystemOut;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Gathers a few tests that focus on WDL workflows, testing things like generation of wdl test parameter files

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WDLWorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WDLWorkflowIT.java
@@ -41,17 +41,24 @@ import io.dockstore.openapi.client.model.WorkflowVersion;
 import io.dropwizard.testing.ResourceHelpers;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.stream.SystemErr;
 import uk.org.webcompere.systemstubs.stream.SystemOut;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
+
+import static io.dockstore.client.cli.ArgumentUtility.CONVERT;
+import static io.dockstore.client.cli.ArgumentUtility.LAUNCH;
+import static io.dockstore.client.cli.Client.CONFIG;
+import static io.dockstore.client.cli.Client.SCRIPT_FLAG;
+import static io.dockstore.client.cli.Client.WORKFLOW;
+import static io.dockstore.client.cli.nested.AbstractEntryClient.ENTRY_2_JSON;
+import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
+import static io.dockstore.client.cli.nested.WesCommandParser.JSON;
+import static io.dockstore.common.DescriptorLanguage.WDL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Gathers a few tests that focus on WDL workflows, testing things like generation of wdl test parameter files

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -16,17 +16,22 @@
 
 package io.dockstore.client.cli;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
-
+import static io.dockstore.client.cli.ArgumentUtility.DOWNLOAD;
+import static io.dockstore.client.cli.ArgumentUtility.LAUNCH;
+import static io.dockstore.client.cli.Client.CHECKER;
+import static io.dockstore.client.cli.Client.CONFIG;
+import static io.dockstore.client.cli.Client.SCRIPT_FLAG;
+import static io.dockstore.client.cli.Client.VERSION;
+import static io.dockstore.client.cli.Client.WORKFLOW;
+import static io.dockstore.client.cli.nested.AbstractEntryClient.PUBLISH;
+import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
+import static io.dockstore.client.cli.nested.WesCommandParser.JSON;
+import static io.dockstore.common.DescriptorLanguage.CWL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.org.webcompere.systemstubs.SystemStubs.catchSystemExit;
 import com.google.common.collect.Lists;
 import io.dockstore.client.cli.nested.WorkflowClient;
 import io.dockstore.common.CLICommonTestUtilities;
@@ -50,23 +55,16 @@ import org.junit.jupiter.api.Test;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.stream.SystemErr;
 import uk.org.webcompere.systemstubs.stream.SystemOut;
-
-import static io.dockstore.client.cli.ArgumentUtility.DOWNLOAD;
-import static io.dockstore.client.cli.ArgumentUtility.LAUNCH;
-import static io.dockstore.client.cli.Client.CHECKER;
-import static io.dockstore.client.cli.Client.CONFIG;
-import static io.dockstore.client.cli.Client.SCRIPT_FLAG;
-import static io.dockstore.client.cli.Client.VERSION;
-import static io.dockstore.client.cli.Client.WORKFLOW;
-import static io.dockstore.client.cli.nested.AbstractEntryClient.PUBLISH;
-import static io.dockstore.client.cli.nested.WesCommandParser.ENTRY;
-import static io.dockstore.client.cli.nested.WesCommandParser.JSON;
-import static io.dockstore.common.DescriptorLanguage.CWL;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.org.webcompere.systemstubs.SystemStubs.catchSystemExit;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 /**
  * Extra confidential integration tests, focus on testing workflow interactions
@@ -222,11 +220,8 @@ class WorkflowIT extends BaseIT {
         Client.main(new String[] { CONFIG, fileWithCorrectCredentials, WORKFLOW, PUBLISH, ENTRY, toolpath, SCRIPT_FLAG });
 
         // should be able to download properly with incorrect credentials because the entry is published
-        catchSystemExit(() -> {
-            // TODO: this catch should not be necessary
-            Client.main(new String[] { CONFIG, fileWithIncorrectCredentials, CHECKER, DOWNLOAD, ENTRY, toolpath, VERSION, "master",
-                    SCRIPT_FLAG });
-        });
+        Client.main(new String[] { CONFIG, fileWithIncorrectCredentials, CHECKER, DOWNLOAD, ENTRY, toolpath, VERSION, "master",
+                SCRIPT_FLAG });
 
         // Unpublish the workflow
         Client.main(


### PR DESCRIPTION
**Description**
Re-enable failing CLI test by turning off Java assertions in the org.hibernate and subpackages. It also enabled the removal of System.exit catch that is no longer necessary.

This is less than ideal, but note that in prod the web service is not running with assertions enabled.

Notes:

* The Surefire plugin by default turns on Java assertions
* I was initially unable to reproduce the bug with a local "regular" web service running, because I don't run the web service with assertions enabled. But If I set a breakpoint in the Java code, in org.hibernate.collection.spi.PersistentMap#injectLoadedState, on the `assert this.isInitializing()`, I can see the assertion would fail if assertions were enabled.
* Semi-digression, I can't even start the web service locally with assertions enabled -- it fails with a NoClassDefFound error, unrelated to Hibernate.
* By default, running a test in IntelliJ enables assertions, which is why it would fail locally. If I run the test with assertions not enabled locally, it passes.

If this approach is agreed upon, I will create a followup ticket to figure out the underlying assertion failure. I think it's there for optimization purposes, i.e., a call is being made to initialize an already initialized collection:

```
	public void injectLoadedState(PluralAttributeMapping attributeMapping, List<?> loadingState) {
		assert isInitializing();
		assert map == null;

		final CollectionPersister collectionDescriptor = attributeMapping.getCollectionDescriptor();
		this.map = (Map<K,E>) collectionDescriptor.getCollectionSemantics().instantiateRaw( loadingState.size(), collectionDescriptor );

		for ( int i = 0; i < loadingState.size(); i++ ) {
			final Object[] keyVal = (Object[]) loadingState.get( i );
			map.put( (K) keyVal[0], (E) keyVal[1] );
		}
	}
```

**Review Instructions**
Since this is a change to an integration test, if the tests pass after it's merged, it's done, and no further review necessary.

**Issue**
SEAB-5854

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
