### PR TITLE
SEAB-6097: Nightly CLI build failure should notify in Slack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,8 @@ common_jobs: &common_jobs
             <<: *common_filters
             requires:
               - find-develop-snapshot
+            context:
+              - oicr-slack-cli
         - unit-tests:
             <<: *common_filters
             requires:
@@ -230,6 +232,13 @@ jobs:
           root: .
           paths:
             - .
+        # Remove nightly condition for now, testing app setup
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+      - slack/notify:
+          event: pass
+          template: basic_success_1
   sonar-cloud:
     docker: # run the steps with Docker
       - image: cimg/openjdk:<< pipeline.parameters.java-tag >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ parameters:
   run_against_develop_core:
     type: boolean
     default: false
+  test_slack: # added temporarily for testing purposes
+    type: boolean
+    default: true
 
 orbs:
   build-tools: circleci/build-tools@2.7.0
@@ -35,6 +38,10 @@ common_filters: &common_filters
       ignore:
         - gh-pages
 
+slack_context: &slack_context
+  context:
+    - oicr-slack
+
 common_jobs: &common_jobs
     jobs:
         # find-develop-snapshot job is run for both "everything" and "nightly" builds even though it's only needed for nightly.
@@ -42,35 +49,35 @@ common_jobs: &common_jobs
         - find-develop-snapshot
         - build:
             <<: *common_filters
+            <<: *slack_context
             requires:
               - find-develop-snapshot
-            context:
-              - oicr-slack
         - unit-tests:
             <<: *common_filters
+            <<: *slack_context
             requires:
               - build
-            context:
-              - oicr-slack
         - integration-tests:
             matrix:
               parameters:
                 testing_profile: [ "singularity-tests", "bitbucket-tests" ]
             <<: *common_filters
+            <<: *slack_context
             requires:
               - build
-            context:
-              - oicr-slack
         - non-confidential-tests:
             <<: *common_filters
+            <<: *slack_context
             requires:
               - build
         - confidential-workflow-tests:
             <<: *common_filters
+            <<: *slack_context
             requires:
               - build
         - confidential-tool-tests:
             <<: *common_filters
+            <<: *slack_context
             requires:
               - build
         - wes-toil-test:
@@ -141,10 +148,7 @@ jobs:
       - save_test_results
       - send_coverage
       - persist_coverage
-      - when:
-          condition: << pipeline.parameters.run_against_develop_core >>
-          steps:
-            - notify-slack
+      - notify-slack
 
   non-confidential-tests:
     executor: machine_integration_test_exec
@@ -189,10 +193,6 @@ jobs:
       MAVEN_GOAL: verify
     steps:
       - setup_and_run_integration_tests
-      - when:
-          condition: << pipeline.parameters.run_against_develop_core >>
-          steps:
-            - notify-slack
 
   wes-toil-test:
     executor: toil_wes_test_executor
@@ -245,10 +245,8 @@ jobs:
           root: .
           paths:
             - .
-      - when:
-          condition: << pipeline.parameters.run_against_develop_core >>
-          steps:
-            - notify-slack
+      - notify-slack
+
   sonar-cloud:
     docker: # run the steps with Docker
       - image: cimg/openjdk:<< pipeline.parameters.java-tag >>
@@ -555,6 +553,7 @@ commands:
       - save_test_results
       - send_coverage
       - persist_coverage
+      - notify-slack
 
   persist_coverage:
     steps:
@@ -570,7 +569,14 @@ commands:
 
   notify-slack:
     steps:
-      - slack/notify:
-          channel: $slack_id
-          event: fail
-          template: basic_fail_1
+      - when:
+          condition: << pipeline.parameters.test_slack >>
+          steps:
+            - slack/notify:
+                channel: $slack_id
+                event: fail
+                template: basic_fail_1
+            - slack/notify: # added temporarily for testing purposes
+                channel: $slack_id
+                event: pass
+                template: basic_success_1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,6 @@ parameters:
   run_against_develop_core:
     type: boolean
     default: false
-  test_slack: # added temporarily for testing purposes
-    type: boolean
-    default: true
 
 orbs:
   build-tools: circleci/build-tools@2.7.0
@@ -570,13 +567,9 @@ commands:
   notify-slack:
     steps:
       - when:
-          condition: << pipeline.parameters.test_slack >>
+          condition: << pipeline.parameters.run_against_develop_core >>
           steps:
             - slack/notify:
                 channel: $slack_id
                 event: fail
                 template: basic_fail_1
-            - slack/notify: # added temporarily for testing purposes
-                channel: $slack_id
-                event: pass
-                template: basic_success_1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,15 +233,13 @@ jobs:
           root: .
           paths:
             - .
-        # Remove nightly condition for now, testing app setup
-      - slack/notify:
-          channel: $slack_id
-          event: fail
-          template: basic_fail_1
-      - slack/notify:
-          channel: $slack_id
-          event: pass
-          template: basic_success_1
+      - when:
+          condition: << pipeline.parameters.run_against_develop_core >>
+          steps:
+            - slack/notify:
+                channel: $slack_id
+                event: fail
+                template: basic_fail_1
   sonar-cloud:
     docker: # run the steps with Docker
       - image: cimg/openjdk:<< pipeline.parameters.java-tag >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,8 @@ common_jobs: &common_jobs
             <<: *common_filters
             requires:
               - build
+            context:
+              - oicr-slack
         - integration-tests:
             matrix:
               parameters:
@@ -57,6 +59,8 @@ common_jobs: &common_jobs
             <<: *common_filters
             requires:
               - build
+            context:
+              - oicr-slack
         - non-confidential-tests:
             <<: *common_filters
             requires:
@@ -137,6 +141,10 @@ jobs:
       - save_test_results
       - send_coverage
       - persist_coverage
+      - when:
+          condition: << pipeline.parameters.run_against_develop_core >>
+          steps:
+            - notify-slack
 
   non-confidential-tests:
     executor: machine_integration_test_exec
@@ -181,6 +189,10 @@ jobs:
       MAVEN_GOAL: verify
     steps:
       - setup_and_run_integration_tests
+      - when:
+          condition: << pipeline.parameters.run_against_develop_core >>
+          steps:
+            - notify-slack
 
   wes-toil-test:
     executor: toil_wes_test_executor
@@ -236,10 +248,7 @@ jobs:
       - when:
           condition: << pipeline.parameters.run_against_develop_core >>
           steps:
-            - slack/notify:
-                channel: $slack_id
-                event: fail
-                template: basic_fail_1
+            - notify-slack
   sonar-cloud:
     docker: # run the steps with Docker
       - image: cimg/openjdk:<< pipeline.parameters.java-tag >>
@@ -558,3 +567,10 @@ commands:
           root: .
           paths:
             - coverage
+
+  notify-slack:
+    steps:
+      - slack/notify:
+          channel: $slack_id
+          event: fail
+          template: basic_fail_1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ parameters:
 
 orbs:
   build-tools: circleci/build-tools@2.7.0
+  slack: circleci/slack@4.4.4
 executors:
   unit_tests_executor:
     docker: # run the steps with Docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ common_jobs: &common_jobs
             requires:
               - find-develop-snapshot
             context:
-              - oicr-slack-cli
+              - oicr-slack
         - unit-tests:
             <<: *common_filters
             requires:
@@ -235,9 +235,11 @@ jobs:
             - .
         # Remove nightly condition for now, testing app setup
       - slack/notify:
+          channel: $slack_id
           event: fail
           template: basic_fail_1
       - slack/notify:
+          channel: $slack_id
           event: pass
           template: basic_success_1
   sonar-cloud:


### PR DESCRIPTION
**Description**
This PR restores the Slack notification for nightly CLI build failures, which was removed after moving the nightly cron to CircleCI (https://github.com/dockstore/dockstore-cli/pull/268). Notifications are set up appear in #dockstore-dev-alerts.

**Review Instructions**
In config.yml, verify that the Slack notification is configured as expected. See https://oicr.slack.com/archives/C0151UDNR9R/p1711479933594839 for a successful test run of the `slack/notify` setup (without the nightly condition).

Since the CLI nightly workflow consists of multiple jobs, the PR currently proposes separate Slack notifications for the build, unit tests, and integration tests. Are there any jobs that should be added/removed?

Note: I originally created a new Slack app called "Dockstore CLI Build", with its own CircleCI context called `oicr-slack-cli`, to do the notifying (test run: https://oicr.slack.com/archives/C0151UDNR9R/p1711465118013749). But it looks like the notification also works with our pre-existing "dockstore build notifications" app and `oicr-slack` context. I decided to stick with the old app for consistency, but do comment if you'd prefer otherwise.

**Issue**
SEAB-6097

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
