### PR TITLE
Fix nightly build failure against develop

### DIFF
--- a/keysmap.list
+++ b/keysmap.list
@@ -68,7 +68,7 @@ org.jboss.logging:jboss-logging:jar:3.4.3.Final = badSig
 org.broadinstitute:cromwell-wdl-transforms-draft2_2.13:jar:84 = badSig
 
 
-
+org.kohsuke:github-api:pom:1.322                                    = badSig
 org.kohsuke:github-api:pom:1.313                                    = badSig
 org.kohsuke:github-api:pom:1.123                                    = badSig
 com.spotify:docker-client:pom:8.16.0                                = badSig


### PR DESCRIPTION
**Description**
A recent web service PR, dockstore/dockstore#/5923, updated the Kohsuke GitHub library, which has a bad signature. This caused the CLI builds against the web service develop branch to fail.

Note that the web service PR also needed to add the `badSig` to keymap.list.

**Review Instructions**
The nightly [builds](https://app.circleci.com/pipelines/github/dockstore/dockstore-cli?branch=develop) here should pass.

**Issue**
SEAB-6567

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
