### PR TITLE
Feature/deprecate icgc

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,6 @@ cache-dir = /home/<user>/.dockstore/cache   #set this to determine where input f
 
 [dockstore-file-s3-plugin]
 endpoint = #set this to point at a non AWS S3 endpoint
-
-[dockstore-file-icgc-storage-client-plugin]
-client = /media/large_volume/icgc-storage-client-1.0.23/bin/icgc-storage-client
 ```
 
 Additional plugins can be created by taking one of the repos in [plugins](https://github.com/dockstore) as a model and 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ server-url = https://www.dockstore.org/api
 
 By default, cwltool reads input files from the local filesystem. Dockstore also adds support for additional file systems
 such as http, https, and ftp. Through a plug-in system, Dockstore also supports 
-the Amazon S3, [Synapse](http://docs.synapse.org/articles/downloading_data.html), and 
-[ICGC Score Client](https://docs.icgc.org/download/guide/#score-client-usage) via [plugins](https://github.com/dockstore).
+the Amazon S3 and [Synapse](https://help.synapse.org/docs/Downloading-Data-Programmatically.2003796248.html), and via [plugins](https://github.com/dockstore).
 
 Download the above set of default plugins via: 
 ```

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
@@ -158,7 +158,6 @@ class ClientIT extends BaseIT {
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("pluginsTest1/configWithPlugins"), PLUGIN, LIST });
         assertTrue(systemOutRule.getText().contains("dockstore-file-synapse-plugin"));
         assertTrue(systemOutRule.getText().contains("dockstore-file-s3-plugin"));
-        assertFalse(systemOutRule.getText().contains("dockstore-icgc-storage-client-plugin"));
     }
 
     @Test
@@ -168,7 +167,6 @@ class ClientIT extends BaseIT {
         Client.main(new String[] { CONFIG, ResourceHelpers.resourceFilePath("pluginsTest2/configWithPlugins"), PLUGIN, LIST });
         assertFalse(systemOutRule.getText().contains("dockstore-file-synapse-plugin"));
         assertFalse(systemOutRule.getText().contains("dockstore-file-s3-plugin"));
-        assertTrue(systemOutRule.getText().contains("dockstore-file-icgc-storage-client-plugin"));
     }
 
     @Disabled("seems to have been disabled for ages")

--- a/dockstore-cli-integration-testing/src/test/resources/pluginsTest1/configWithPlugins
+++ b/dockstore-cli-integration-testing/src/test/resources/pluginsTest1/configWithPlugins
@@ -2,16 +2,9 @@ token: test
 server-url: https://www.dockstore.org/api
 file-plugins-location: src/test/resources/pluginsTest1/plugins
 
-[dockstore-icgc-get-plugin]
-client = /home/gluu/icgc-get/icgc-get
-config-file-location = /home/gluu/.icgc-get/config.yaml
-
 [dockstore-s3cmd-plugin]
 client = /usr/bin/s3cmd
 config-file-location = /home/gluu/.s3cfg
-
-[dockstore-file-icgc-storage-client-plugin]
-client = asdf
 
 [dockstore-file-s3-plugin]
 client = asdf

--- a/dockstore-cli-integration-testing/src/test/resources/pluginsTest2/configWithPlugins
+++ b/dockstore-cli-integration-testing/src/test/resources/pluginsTest2/configWithPlugins
@@ -2,16 +2,9 @@ token: test
 server-url: https://www.dockstore.org/api
 file-plugins-location: src/test/resources/pluginsTest2/plugins
 
-[dockstore-icgc-get-plugin]
-client = /home/gluu/icgc-get/icgc-get
-config-file-location = /home/gluu/.icgc-get/config.yaml
-
 [dockstore-s3cmd-plugin]
 client = /usr/bin/s3cmd
 config-file-location = /home/gluu/.s3cfg
-
-[dockstore-file-icgc-storage-client-plugin]
-client = asdf
 
 [dockstore-file-s3-plugin]
 client = asdf

--- a/dockstore-client/README.md
+++ b/dockstore-client/README.md
@@ -30,7 +30,7 @@ This takes a CWL-based descriptor along with a JSON file that specifies paramete
 0. pulls over 0 or more files that were associated with this workflow order to `/datastore/launcher-<uuid>/configs`, these will be used by the workflow itself. These will come from a web service endpoint in Consonance rather than external sources like inputs below. This is how we get a SeqWare INI file for example. For this demo launcher this functionality will be skipped since it lacks a queue/web service to talk to. 
 0. make `/datastore/launcher-<uuid>/working` to be used as the working directory for the command, `/datastore/launcher-<uuid>/inputs` for all the file inputs, and `/datastore/launcher-<uuid>/logs` for logs
 0. start services referenced in the descriptor, this functionality does not yet exist
-0. download all the inputs, these will come from S3, HTTP/S, SFTP, FTP, ICGCObjectStore, etc, put them in locations within `/datastore/launcher-<uuid>/inputs`
+0. download all the inputs, these will come from S3, HTTP/S, SFTP, FTP, etc, put them in locations within `/datastore/launcher-<uuid>/inputs`
 0. produces a new JSON parameterization document that has the URLs replaced with file paths that are local to the container host
 0. hands the updated JSON parameterization document and CWL descriptor to the CWL runner tool, this causes the command to be constructed, docker containers to be pulled and the command to be run correctly
 0. collect and provision output files to their destination referenced in `~/.consonance/launcher.config`
@@ -43,10 +43,6 @@ working-directory=./datastore/
 [s3]
 # optional: the S3 endpoint can be overridden to use custom implementations of the S3 API rather than AWS S3
 # endpoint = https://www.cancercollaboratory.org:9080
-
-[dcc_storage]
-# optional: the location of the DCC storage client can be customized 
-# client = /icgc/dcc-storage/bin/dcc-storage-client
 ```
 
 This tells the system what the local working directory should be.  Files will be written here.

--- a/dockstore-client/src/main/resources/plugins.json
+++ b/dockstore-client/src/main/resources/plugins.json
@@ -1,7 +1,4 @@
   [{
-    "name": "dockstore-file-icgc-storage-client-plugin",
-    "version": "0.0.6"
-  },{
     "name": "dockstore-file-s3-plugin",
     "version": "0.0.3"
   },{

--- a/dockstore-file-plugin-parent/README.md
+++ b/dockstore-file-plugin-parent/README.md
@@ -21,7 +21,7 @@ Use the following command to list currently installed plugins
 dockstore plugin list
 ```
 
-This will list the plugins along with their versions, their install locations, and the schemes that they handle (ex: `s3:\\test.txt` , `icgc:\\123-456` , `syn:\\syn12345` ). 
+This will list the plugins along with their versions, their install locations, and the schemes that they handle (ex: `s3:\\test.txt`, `syn:\\syn12345` ). 
 
 Note that dockstore will automatically delete old versions of plugins when you install new plugins. 
 
@@ -34,9 +34,6 @@ synapse-api-key = dummy-key
 synapse-user-name = my.user.name 
 
 [dockstore-file-s3-plugin]
-
-[dockstore-file-icgc-storage-client-plugin]
-client = /media/large_volume/icgc-storage-client-1.0.23/bin/icgc-storage-client
 ```
 
 
@@ -44,7 +41,7 @@ client = /media/large_volume/icgc-storage-client-1.0.23/bin/icgc-storage-client
 
 When developing new plugins, we recommend using the [s3-plugin](https://github.com/dockstore/s3-plugin) as a model for 
 plugins where [a Java library is available](https://aws.amazon.com/sdk-for-java/).
-We recommend using the [icgc-storage-client-plugin](https://github.com/dockstore/icgc-storage-client-plugin) as a model for 
+Although it is no longer directly supported, we recommend using the [icgc-storage-client-plugin](https://github.com/dockstore/icgc-storage-client-plugin) as a model for 
 plugins where a Java library is not available and the plugin needs to call out to an external binary. 
 
 This was developed in an environment with Java 8 and Maven 3.3.9. 

--- a/dockstore-file-plugin-parent/src/main/java/io/dockstore/provision/ProvisionInterface.java
+++ b/dockstore-file-plugin-parent/src/main/java/io/dockstore/provision/ProvisionInterface.java
@@ -29,7 +29,7 @@ public interface ProvisionInterface extends ExtensionPoint {
 
     /**
      * Returns whether a particular file path should be handled by this plugin
-     * @return return schemes that this provision interface handles (ex: http, https, ftp, syn, icgc)
+     * @return return schemes that this provision interface handles (ex: http, https, ftp, syn)
      */
     Set<String> schemesHandled();
 


### PR DESCRIPTION
**Description**
Remove references to icgc in terms of support. 
Remove icgc plugin for example and some tests

**Review Instructions**
Build should pass. When running a clean develop cli, the icgc plugin should not longer be downloaded at the start. 

**Issue**
https://github.com/dockstore/dockstore/issues/5925

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
