### PR TITLE
Update webservice tag after hotfix merge

### DIFF
--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -158,7 +158,7 @@ Lists of 394 third-party dependencies.
      (The Apache Software License, Version 2.0) FindBugs-jsr305 (com.google.code.findbugs:jsr305:3.0.2 - http://findbugs.sourceforge.net/)
      (The Apache Software License, Version 2.0) GeantyRef (io.leangen.geantyref:geantyref:1.3.14 - https://github.com/leangen/geantyref)
      (Apache 2.0) genericExtras (io.circe:circe-generic-extras_2.13:0.14.1 - https://github.com/circe/circe-generic-extras)
-     (The MIT license) GitHub API for Java (org.kohsuke:github-api:1.313 - https://github-api.kohsuke.org/)
+     (The MIT license) GitHub API for Java (org.kohsuke:github-api:1.322 - https://github-api.kohsuke.org/)
      (The Apache Software License, Version 2.0) Gitlab Java API Wrapper (org.gitlab:java-gitlab-api:4.0.0 - http://nexus.sonatype.org/oss-repository-hosting.html/java-gitlab-api)
      (The Apache Software License, Version 2.0) Google APIs Client Library for Java (com.google.api-client:google-api-client:1.35.0 - https://github.com/googleapis/google-api-java-client/google-api-client)
      (BSD New license) Google Auth Library for Java - Credentials (com.google.auth:google-auth-library-credentials:1.5.3 - https://github.com/googleapis/google-auth-library-java/google-auth-library-credentials)

--- a/dockstore-cli-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-cli-integration-testing/generated/src/main/resources/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-integration-testing</artifactId>
-      <version>1.16.0-alpha.11</version>
+      <version>1.16.0-alpha.15</version>
       <classifier>tests</classifier>
       <scope>compile</scope>
       <exclusions>
@@ -49,13 +49,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.16.0-alpha.11</version>
+      <version>1.16.0-alpha.15</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.16.0-alpha.11</version>
+      <version>1.16.0-alpha.15</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>openapi-java-client</artifactId>
-      <version>1.16.0-alpha.11</version>
+      <version>1.16.0-alpha.15</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-cli-reports/generated/src/main/resources/pom.xml
+++ b/dockstore-cli-reports/generated/src/main/resources/pom.xml
@@ -30,13 +30,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.16.0-alpha.11</version>
+      <version>1.16.0-alpha.15</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.16.0-alpha.11</version>
+      <version>1.16.0-alpha.15</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-client/generated/src/main/resources/pom.xml
+++ b/dockstore-client/generated/src/main/resources/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.16.0-alpha.11</version>
+      <version>1.16.0-alpha.15</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>openapi-java-client</artifactId>
-      <version>1.16.0-alpha.11</version>
+      <version>1.16.0-alpha.15</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
         <github.url>scm:git:git@github.com:dockstore/dockstore-cli.git</github.url>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dockstore-core.version>1.16.0-alpha.11</dockstore-core.version>
+        <dockstore-core.version>1.16.0-alpha.15</dockstore-core.version>
         <maven-failsafe.version>2.22.2</maven-failsafe.version>
         <maven-surefire.version>2.22.2</maven-surefire.version>
         <skipTests>false</skipTests>

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -14,7 +14,7 @@ fi
 if [ "${TESTING_PROFILE}" = "toil-integration-tests" ]; then
     pip3 install --user toil[cwl]==3.15.0
 else
-    pip3 install --user -r https://raw.githubusercontent.com/dockstore/dockstore/hotfix/1.15.4/dockstore-webservice/src/main/resources/requirements/1.15.0/requirements3.txt
+    pip3 install --user -r https://raw.githubusercontent.com/dockstore/dockstore/develop/dockstore-webservice/src/main/resources/requirements/1.15.0/requirements3.txt
 fi
 
 if [ "${TESTING_PROFILE}" = "singularity-tests" ]; then


### PR DESCRIPTION
**Description**
This PR fixes the CLI build, which started failing when I merged the hotfix tag to develop, by updating the webservice tag. I created a new webservice tag after the hotfix release tag was merged to develop.

**Review Instructions**
Builds should pass

**Issue**
n/a

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
