### PR TITLE
java 21 compatibility and minor version iteration

### DIFF
--- a/dockstore-cli-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-cli-integration-testing/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-cli-integration-testing</artifactId>
-  <version>1.15.0-SNAPSHOT</version>
+  <version>1.16.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-client</artifactId>
-      <version>1.15.0-SNAPSHOT</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-cli-integration-testing/pom.xml
+++ b/dockstore-cli-integration-testing/pom.xml
@@ -291,9 +291,12 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.scala-tools</groupId>
-                <artifactId>maven-scala-plugin</artifactId>
+	    <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <configuration>
+                    <scalaVersion>2.13.12</scalaVersion>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/dockstore-cli-reports/generated/src/main/resources/pom.xml
+++ b/dockstore-cli-reports/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-cli-reports</artifactId>
-  <version>1.15.0-SNAPSHOT</version>
+  <version>1.16.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -42,13 +42,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-client</artifactId>
-      <version>1.15.0-SNAPSHOT</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-cli-integration-testing</artifactId>
-      <version>1.15.0-SNAPSHOT</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/dockstore-client/generated/src/main/resources/pom.xml
+++ b/dockstore-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-client</artifactId>
-  <version>1.15.0-SNAPSHOT</version>
+  <version>1.16.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -84,13 +84,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>openapi-java-wes-client</artifactId>
-      <version>1.15.0-SNAPSHOT</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-file-plugin-parent</artifactId>
-      <version>1.15.0-SNAPSHOT</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-file-plugin-parent/generated/src/main/resources/pom.xml
+++ b/dockstore-file-plugin-parent/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-file-plugin-parent</artifactId>
-  <version>1.15.0-SNAPSHOT</version>
+  <version>1.16.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/openapi-java-wes-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-wes-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>openapi-java-wes-client</artifactId>
-  <version>1.15.0-SNAPSHOT</version>
+  <version>1.16.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     -->
     <properties>
         <!-- the following properties set sane defaults when no revision properties are set from the command-line -->
-        <revision>1.15</revision>
+        <revision>1.16</revision>
         <changelist>.0-SNAPSHOT</changelist>
 
         <github.url>scm:git:git@github.com:dockstore/dockstore-cli.git</github.url>

--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.8</version>
+                    <version>0.8.11</version>
                 </plugin>
                 <plugin>
                     <groupId>com.googlecode.maven-download-plugin</groupId>
@@ -391,7 +391,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>4.6.0.0</version>
+                    <version>4.8.6.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -424,11 +424,13 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.3.2</version>
                 </plugin>
-                <!-- https://mvnrepository.com/artifact/org.scala-tools/maven-scala-plugin -->
-                <plugin>
-                    <groupId>org.scala-tools</groupId>
-                    <artifactId>maven-scala-plugin</artifactId>
-                    <version>2.15.2</version>
+		<plugin>
+                    <groupId>net.alchim31.maven</groupId>
+                    <artifactId>scala-maven-plugin</artifactId>
+                    <version>4.8.1</version>
+                    <configuration>
+                        <release>${maven-java.version}</release>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -542,7 +544,7 @@
                                     <version>3.8.1</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>[11.0.11,18.0)</version>
+                                    <version>[17.0,22.0)</version>
                                 </requireJavaVersion>
                                 <banDuplicatePomDependencyVersions />
                                 <bannedDependencies>

--- a/support/generated/src/main/resources/pom.xml
+++ b/support/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>support</artifactId>
-  <version>1.15.0-SNAPSHOT</version>
+  <version>1.16.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>


### PR DESCRIPTION
**Description**
Noticed CLI nightly builds have been failing since August 10th, investigating. 
Added Java 21 compatibility (this is different from https://github.com/dockstore/dockstore-cli/pull/293 in that this branch only allows us to work with Java 21 locally whereas that branch does the actual testing on Java 21 in a newer machine image)

Also iterated the minor version. Noticed that some nightly regression tests were failing, expecting older versions of cwltool. 
Think that our client was testing itself as a 15.0-SNAPSHOT and thus getting the wrong requirements file after https://github.com/dockstore/dockstore/pull/5958

**Review Instructions**
Wait a day and see if nightly build passes

**Issue**
n/a

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
