### PR TITLE
allow nightly builds to ignore artifact uploads from feature branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,8 @@ jobs:
             - run:
                 name: findDevelopSnapshot
                 command: |
-                  ./mvnw versions:update-properties -Dincludes=io.dockstore:* -DallowSnapshots
+                  # grab the latest snapshot version that doesn't seem to correspond to a feature branch or similar
+                  ./mvnw versions:update-properties -Dincludes="io.dockstore:*" -Dmaven.version.ignore=\.*-\.*-SNAPSHOT -DallowSnapshots
             - run:
                 name: force update to latest snapshot versions, # review this step to see what versions were used, also see https://stackoverflow.com/questions/29020716/maven-what-does-u-update-snapshots-really-do
                 command: |

--- a/pom.xml
+++ b/pom.xml
@@ -424,7 +424,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.10.0</version>
+                    <version>2.18.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
**Description**
Build failure for CLI nightly build traced initially to bad semantic versioning for uploaded artifacts from latter linked ticket. 
To better address the spirit of the nightly build, instructed Maven to only update to snapshot versions that do not seem to come from feature branches and release branches (which will have an extra hyphen as described in linked ticket)

**Review Instructions**
See if nightly builds succeed after merge

**Issue**
While working on https://ucsc-cgl.atlassian.net/browse/SEAB-6808 had interaction with
https://github.com/dockstore/dockstore/pull/6043 or more accurately https://github.com/dockstore/workflow-actions/pull/3

**Security**
None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
