### PR TITLE
simple password vault integration based on psql suggestion

### DIFF
--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
@@ -270,7 +270,7 @@ class ClientIT extends BaseIT {
 
     @Test
     void testTokenCommand() {
-        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("clientConfig.withTokenCommand"), "--debug", "--script" });
+        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("clientConfig.withTokenCommand"), "--debug", "deps" });
         assertTrue(systemOutRule.getText().contains("Hello World!"));
         systemOutRule.clear();
     }

--- a/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
+++ b/dockstore-cli-integration-testing/src/test/java/io/dockstore/client/cli/ClientIT.java
@@ -269,6 +269,13 @@ class ClientIT extends BaseIT {
     }
 
     @Test
+    void testTokenCommand() {
+        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("clientConfig.withTokenCommand"), "--debug", "--script" });
+        assertTrue(systemOutRule.getText().contains("Hello World!"));
+        systemOutRule.clear();
+    }
+
+    @Test
     void testCacheCleaning() throws IOException {
         Client.main(new String[] { CONFIG, TestUtility.getConfigFileLocation(true), CLEAN_CACHE });
         systemOutRule.clear();

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -61,10 +61,12 @@ import io.dockstore.openapi.client.model.TRSService;
 import io.github.collaboratory.cwl.cwlrunner.CWLRunnerFactory;
 import io.github.collaboratory.cwl.cwlrunner.CWLRunnerInterface;
 import jakarta.ws.rs.ProcessingException;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.text.ParseException;
@@ -806,8 +808,7 @@ public class Client {
     }
 
     public static List<String> getGeneralFlags() {
-        List<String> generalFlags = new ArrayList<>();
-        generalFlags.addAll(Arrays.asList(DEBUG_FLAG, HELP, CONFIG, SCRIPT_FLAG));
+        List<String> generalFlags = new ArrayList<>(Arrays.asList(DEBUG_FLAG, HELP, CONFIG, SCRIPT_FLAG));
         return generalFlags;
     }
 
@@ -821,6 +822,14 @@ public class Client {
         INIConfiguration config = getIniConfiguration(args);
         // pull out the variables from the config
         String token = config.getString("token", "");
+        if (token.isEmpty()) {
+            String tokenCommand = config.getString("tokenCommand", "");
+            if (!tokenCommand.isEmpty()) {
+                ByteArrayOutputStream output = new ByteArrayOutputStream();
+                Utilities.executeCommand(tokenCommand, output, new ByteArrayOutputStream());
+                token = output.toString(StandardCharsets.UTF_8).trim();
+            }
+        }
         serverUrl = config.getString("server-url", "https://dockstore.org/api");
         if (serverUrl.contains(":8443")) {
             err(DEPRECATED_PORT_MESSAGE);

--- a/dockstore-client/src/test/resources/clientConfig.withTokenCommand
+++ b/dockstore-client/src/test/resources/clientConfig.withTokenCommand
@@ -1,0 +1,1 @@
+tokenCommand: echo "Hello World!"


### PR DESCRIPTION
**Description**
Inspired by https://postgrespro.com/list/thread-id/2396558 a proposal on how to make pgsql and it's use of pgpass more secure. That proposal did not seem to come to fruition, but seems like a simple/elegant way to allow a user concerned about storing passwords/auth tokens on disk to store them instead in some kind of password vault or manager. 

**Review Instructions**
Use the CLI, put your token in another file and `cat` it as a `tokenCommand`
Spun off documentation as https://ucsc-cgl.atlassian.net/browse/SEAB-7171


**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7032

**Security**
None, this is intended to improve security by providing a workaround to storing the auth token on disk. 

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
