### PR TITLE
key update from webservice

### DIFF
--- a/dockstore-cli-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-cli-integration-testing/generated/src/main/resources/pom.xml
@@ -117,6 +117,13 @@
   </dependencies>
   <repositories>
     <repository>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>artifacts.oicr.on.ca.ca-snapshots</id>
+      <url>https://artifacts.oicr.on.ca/artifactory/collab-snapshot</url>
+    </repository>
+    <repository>
       <id>artifacts.oicr.on.ca</id>
       <name>artifacts.oicr.on.ca</name>
       <url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>

--- a/dockstore-cli-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-cli-integration-testing/generated/src/main/resources/pom.xml
@@ -117,16 +117,6 @@
   </dependencies>
   <repositories>
     <repository>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>artifacts.oicr.on.ca.ca-snapshots</id>
-      <url>https://artifacts.oicr.on.ca/artifactory/collab-snapshot</url>
-    </repository>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
       <id>artifacts.oicr.on.ca</id>
       <name>artifacts.oicr.on.ca</name>
       <url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>
@@ -135,11 +125,6 @@
       <id>broad-dependencies.oicr.on.ca</id>
       <name>broad-dependencies.oicr.on.ca</name>
       <url>https://artifacts.oicr.on.ca/artifactory/broad-dependencies</url>
-    </repository>
-    <repository>
-      <id>apache-releases</id>
-      <name>Apache Releases repository</name>
-      <url>https://repository.apache.org/content/repositories/releases/</url>
     </repository>
     <repository>
       <releases>

--- a/dockstore-cli-reports/generated/src/main/resources/pom.xml
+++ b/dockstore-cli-reports/generated/src/main/resources/pom.xml
@@ -60,6 +60,13 @@
   </dependencies>
   <repositories>
     <repository>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>artifacts.oicr.on.ca.ca-snapshots</id>
+      <url>https://artifacts.oicr.on.ca/artifactory/collab-snapshot</url>
+    </repository>
+    <repository>
       <id>artifacts.oicr.on.ca</id>
       <name>artifacts.oicr.on.ca</name>
       <url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>

--- a/dockstore-cli-reports/generated/src/main/resources/pom.xml
+++ b/dockstore-cli-reports/generated/src/main/resources/pom.xml
@@ -60,16 +60,6 @@
   </dependencies>
   <repositories>
     <repository>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>artifacts.oicr.on.ca.ca-snapshots</id>
-      <url>https://artifacts.oicr.on.ca/artifactory/collab-snapshot</url>
-    </repository>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
       <id>artifacts.oicr.on.ca</id>
       <name>artifacts.oicr.on.ca</name>
       <url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>
@@ -78,11 +68,6 @@
       <id>broad-dependencies.oicr.on.ca</id>
       <name>broad-dependencies.oicr.on.ca</name>
       <url>https://artifacts.oicr.on.ca/artifactory/broad-dependencies</url>
-    </repository>
-    <repository>
-      <id>apache-releases</id>
-      <name>Apache Releases repository</name>
-      <url>https://repository.apache.org/content/repositories/releases/</url>
     </repository>
     <repository>
       <releases>

--- a/dockstore-client/generated/src/main/resources/pom.xml
+++ b/dockstore-client/generated/src/main/resources/pom.xml
@@ -377,6 +377,13 @@
   </dependencies>
   <repositories>
     <repository>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>artifacts.oicr.on.ca.ca-snapshots</id>
+      <url>https://artifacts.oicr.on.ca/artifactory/collab-snapshot</url>
+    </repository>
+    <repository>
       <id>artifacts.oicr.on.ca</id>
       <name>artifacts.oicr.on.ca</name>
       <url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>

--- a/dockstore-client/generated/src/main/resources/pom.xml
+++ b/dockstore-client/generated/src/main/resources/pom.xml
@@ -377,16 +377,6 @@
   </dependencies>
   <repositories>
     <repository>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>artifacts.oicr.on.ca.ca-snapshots</id>
-      <url>https://artifacts.oicr.on.ca/artifactory/collab-snapshot</url>
-    </repository>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
       <id>artifacts.oicr.on.ca</id>
       <name>artifacts.oicr.on.ca</name>
       <url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>
@@ -395,11 +385,6 @@
       <id>broad-dependencies.oicr.on.ca</id>
       <name>broad-dependencies.oicr.on.ca</name>
       <url>https://artifacts.oicr.on.ca/artifactory/broad-dependencies</url>
-    </repository>
-    <repository>
-      <id>apache-releases</id>
-      <name>Apache Releases repository</name>
-      <url>https://repository.apache.org/content/repositories/releases/</url>
     </repository>
     <repository>
       <releases>

--- a/dockstore-file-plugin-parent/generated/src/main/resources/pom.xml
+++ b/dockstore-file-plugin-parent/generated/src/main/resources/pom.xml
@@ -42,6 +42,13 @@
   </dependencies>
   <repositories>
     <repository>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>artifacts.oicr.on.ca.ca-snapshots</id>
+      <url>https://artifacts.oicr.on.ca/artifactory/collab-snapshot</url>
+    </repository>
+    <repository>
       <id>artifacts.oicr.on.ca</id>
       <name>artifacts.oicr.on.ca</name>
       <url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>

--- a/dockstore-file-plugin-parent/generated/src/main/resources/pom.xml
+++ b/dockstore-file-plugin-parent/generated/src/main/resources/pom.xml
@@ -42,16 +42,6 @@
   </dependencies>
   <repositories>
     <repository>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>artifacts.oicr.on.ca.ca-snapshots</id>
-      <url>https://artifacts.oicr.on.ca/artifactory/collab-snapshot</url>
-    </repository>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
       <id>artifacts.oicr.on.ca</id>
       <name>artifacts.oicr.on.ca</name>
       <url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>
@@ -60,11 +50,6 @@
       <id>broad-dependencies.oicr.on.ca</id>
       <name>broad-dependencies.oicr.on.ca</name>
       <url>https://artifacts.oicr.on.ca/artifactory/broad-dependencies</url>
-    </repository>
-    <repository>
-      <id>apache-releases</id>
-      <name>Apache Releases repository</name>
-      <url>https://repository.apache.org/content/repositories/releases/</url>
     </repository>
     <repository>
       <releases>

--- a/keysmap.list
+++ b/keysmap.list
@@ -1,14 +1,14 @@
 io.swagger.core.v3:swagger-annotations:jar:2.1.7 			        = noSig
-com.fasterxml.jackson.datatype:jackson-datatype-joda:pom:2.18.2     = badSig
-com.fasterxml.jackson.core:jackson-databind:pom:2.18.2                      = badSig
-com.fasterxml.jackson.core:jackson-annotations:pom:2.18.2           = badSig
-com.fasterxml.jackson.core:jackson-core:pom:2.18.2                              = badSig
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:pom:2.18.2  = badSig
 com.fasterxml.jackson.datatype:jackson-datatype-joda:pom:2.18.3     = badSig
 com.fasterxml.jackson.core:jackson-databind:pom:2.18.3                      = badSig
 com.fasterxml.jackson.core:jackson-annotations:pom:2.18.3           = badSig
 com.fasterxml.jackson.core:jackson-core:pom:2.18.3                              = badSig
 com.fasterxml.jackson.dataformat:jackson-dataformat-xml:pom:2.18.3  = badSig
+com.fasterxml.jackson.datatype:jackson-datatype-joda:pom:2.19.0     = badSig
+com.fasterxml.jackson.core:jackson-databind:pom:2.19.0 			    = badSig
+com.fasterxml.jackson.core:jackson-annotations:pom:2.19.0	    = badSig
+com.fasterxml.jackson.core:jackson-core:pom:2.19.0			        = badSig
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:pom:2.19.0  = badSig
 
 org.broadinstitute:wdl-draft3_2.13:pom:84 = badSig
 org.broadinstitute:wdl-biscayne_2.13:pom:84 = badSig

--- a/openapi-java-wes-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-wes-client/generated/src/main/resources/pom.xml
@@ -96,6 +96,13 @@
   </dependencies>
   <repositories>
     <repository>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>artifacts.oicr.on.ca.ca-snapshots</id>
+      <url>https://artifacts.oicr.on.ca/artifactory/collab-snapshot</url>
+    </repository>
+    <repository>
       <id>artifacts.oicr.on.ca</id>
       <name>artifacts.oicr.on.ca</name>
       <url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>

--- a/openapi-java-wes-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-wes-client/generated/src/main/resources/pom.xml
@@ -96,16 +96,6 @@
   </dependencies>
   <repositories>
     <repository>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>artifacts.oicr.on.ca.ca-snapshots</id>
-      <url>https://artifacts.oicr.on.ca/artifactory/collab-snapshot</url>
-    </repository>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
       <id>artifacts.oicr.on.ca</id>
       <name>artifacts.oicr.on.ca</name>
       <url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>
@@ -114,11 +104,6 @@
       <id>broad-dependencies.oicr.on.ca</id>
       <name>broad-dependencies.oicr.on.ca</name>
       <url>https://artifacts.oicr.on.ca/artifactory/broad-dependencies</url>
-    </repository>
-    <repository>
-      <id>apache-releases</id>
-      <name>Apache Releases repository</name>
-      <url>https://repository.apache.org/content/repositories/releases/</url>
     </repository>
     <repository>
       <releases>

--- a/pom.xml
+++ b/pom.xml
@@ -70,35 +70,20 @@
 
     <repositories>
         <repository>
-            <id>artifacts.oicr.on.ca.ca-snapshots</id>
-            <url>https://artifacts.oicr.on.ca/artifactory/collab-snapshot</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
             <id>artifacts.oicr.on.ca</id>
             <name>artifacts.oicr.on.ca</name>
             <url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
         </repository>
         <repository>
             <id>broad-dependencies.oicr.on.ca</id>
             <name>broad-dependencies.oicr.on.ca</name>
             <url>https://artifacts.oicr.on.ca/artifactory/broad-dependencies</url>
         </repository>
-        <repository>
-            <id>apache-releases</id>
-            <name>Apache Releases repository</name>
-            <url>https://repository.apache.org/content/repositories/releases/</url>
-        </repository>
         <!-- broad -->
         <repository>
             <id>artifactory.broadinstitute.org</id>
             <name>artifactory.broadinstitute.org</name>
-	    <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
+            <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -106,6 +91,12 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
+        <!-- might be useful someday in a pinch if oicr goes down again
+        <repository>
+            <id>gitlab-maven</id>
+            <url>https://gitlab.com/api/v4/projects/17865731/packages/maven</url>
+        </repository>
+        -->
     </repositories>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,13 @@
     </scm>
 
     <repositories>
+	<repository>
+            <id>artifacts.oicr.on.ca.ca-snapshots</id>
+            <url>https://artifacts.oicr.on.ca/artifactory/collab-snapshot</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
         <repository>
             <id>artifacts.oicr.on.ca</id>
             <name>artifacts.oicr.on.ca</name>

--- a/support/generated/src/main/resources/pom.xml
+++ b/support/generated/src/main/resources/pom.xml
@@ -84,6 +84,13 @@
   </dependencies>
   <repositories>
     <repository>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>artifacts.oicr.on.ca.ca-snapshots</id>
+      <url>https://artifacts.oicr.on.ca/artifactory/collab-snapshot</url>
+    </repository>
+    <repository>
       <id>artifacts.oicr.on.ca</id>
       <name>artifacts.oicr.on.ca</name>
       <url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>

--- a/support/generated/src/main/resources/pom.xml
+++ b/support/generated/src/main/resources/pom.xml
@@ -84,16 +84,6 @@
   </dependencies>
   <repositories>
     <repository>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>artifacts.oicr.on.ca.ca-snapshots</id>
-      <url>https://artifacts.oicr.on.ca/artifactory/collab-snapshot</url>
-    </repository>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
       <id>artifacts.oicr.on.ca</id>
       <name>artifacts.oicr.on.ca</name>
       <url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>
@@ -102,11 +92,6 @@
       <id>broad-dependencies.oicr.on.ca</id>
       <name>broad-dependencies.oicr.on.ca</name>
       <url>https://artifacts.oicr.on.ca/artifactory/broad-dependencies</url>
-    </repository>
-    <repository>
-      <id>apache-releases</id>
-      <name>Apache Releases repository</name>
-      <url>https://repository.apache.org/content/repositories/releases/</url>
     </repository>
     <repository>
       <releases>


### PR DESCRIPTION
**Description**
Fix broken nightly builds with snapshot of webservice build (need to update keymap)
While at it, removed an artifactory description that seems to slow down builds a lot, not sure why but it seems to (replicated locally)

**Review Instructions**
Wait till next nightly cli build, see if it passes or continues to get a gpg error

**Issue**
n/a

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `./mvnw clean install` 
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.
